### PR TITLE
Fix TMPDIR backup

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -43,7 +43,7 @@ use_nix() {
     log_status using cached derivation
   fi
   local term_backup=$TERM path_backup=$PATH
-  if [[ -z ${TMPDIR+x} ]]; then
+  if [[ ! -z ${TMPDIR+x} ]]; then
     local tmp_backup=$TMPDIR
   fi
 
@@ -51,7 +51,7 @@ use_nix() {
   read -r cache_content < "$cache"
   eval "$cache_content"
   export PATH=$PATH:$path_backup TERM=$term_backup TMPDIR=$tmp_backup
-  if [ -z ${tmp_backup+x} ]; then
+  if [ ! -z ${tmp_backup+x} ]; then
     export TMPDIR=${tmp_backup}
   else
     unset TMPDIR

--- a/direnvrc
+++ b/direnvrc
@@ -50,8 +50,8 @@ use_nix() {
   log_status eval "$cache"
   read -r cache_content < "$cache"
   eval "$cache_content"
-  export PATH=$PATH:$path_backup TERM=$term_backup TMPDIR=$tmp_backup
-  if [ ! -z ${tmp_backup+x} ]; then
+  export PATH=$PATH:$path_backup TERM=$term_backup 
+  if [[ ! -z ${tmp_backup+x} ]]; then
     export TMPDIR=${tmp_backup}
   else
     unset TMPDIR


### PR DESCRIPTION
This was clearing TMPDIR since it was first not setting the
`tmp_backup` local variable, and then, since `tmp_backup` was null, it
was unsetting TMPDIR.