### PR TITLE
Update README.md with nix.conf changes needed for persistent derivations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ Then source the direnvrc from this repository in your own `.direnvrc`
 # put this in ~/.direnvrc
 source $HOME/.nix-direnv/direnvrc
 ```
+
+For derivations to persist garbage collection, set the following in nix.conf:
+
+```
+keep-derivations = true
+keep-outputs = true
+```


### PR DESCRIPTION
It appears that the derivations produced by nix-direnv are removed when running nix's garbage collection. Troubleshooting this issue led me to [a git issue][1] in the NixOS/nix repo. Enabling both `keep-derivations` and `keep-outputs` worked for me as recommended, and now nix-direnv is working.

[1]: https://github.com/NixOS/nix/issues/2208