### PR TITLE
Fix persistent derivation when not using default direnv-layout-dir

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -84,7 +84,7 @@ use_nix() {
     local escaped_pwd=${stripped_pwd//-/--}
     local escaped_pwd=${escaped_pwd//\//-}
     ln -fs "$drv" "$drv_link"
-    ln -fs "$PWD/$drv_link" "/nix/var/nix/gcroots/per-user/$LOGNAME/$escaped_pwd"
+    ln -fs "$(realpath -s $drv_link)" "/nix/var/nix/gcroots/per-user/$LOGNAME/$escaped_pwd"
     log_status renewed cache and derivation link
   fi
 


### PR DESCRIPTION
As mentioned in a later post in #11, current `master` breaks the persistent derivation (prevent-garbage-collection) feature when using a non-default `direnv_layout_dir`.

Here's my naive take on fixing that. I've tried this "fix" both with and without `direnv_layout_dir` explicitly set, and it appears to be working.

The main problem with this fix is that now `realpath` is needed (part of the `coreutils` derivation in Nix).