### PR TITLE
direnvrc: do not set an empty NIX_SSL_CERT_FILE

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -47,8 +47,8 @@ use_nix() {
     local tmp_backup=$TMPDIR
   fi
 
-  local impure_ssl_cert_file=${SSL_CERT_FILE:-}
-  local impure_nix_ssl_cert_file=${NIX_SSL_CERT_FILE:-}
+  local impure_ssl_cert_file=${SSL_CERT_FILE:-__UNSET__}
+  local impure_nix_ssl_cert_file=${NIX_SSL_CERT_FILE:-__UNSET__}
 
   log_status eval "$cache"
   read -r cache_content < "$cache"
@@ -62,17 +62,17 @@ use_nix() {
 
   # `nix-shell --pure` sets invalid ssl certificate paths
   if [[ "${SSL_CERT_FILE:-}" = /no-cert-file.crt ]]; then
-    if [[ -n ${impure_ssl_cert_file+x} ]]; then
-      export SSL_CERT_FILE=${impure_ssl_cert_file}
-    else
+    if [[ ${impure_ssl_cert_file} == __UNSET__ ]]; then
       unset SSL_CERT_FILE
+    else
+      export SSL_CERT_FILE=${impure_ssl_cert_file}
     fi
   fi
   if [[ "${NIX_SSL_CERT_FILE:-}" = /no-cert-file.crt ]]; then
-    if [[ -n ${impure_nix_ssl_cert_file+x} ]]; then
-      export NIX_SSL_CERT_FILE=${impure_nix_ssl_cert_file}
-    else
+    if [[ ${impure_nix_ssl_cert_file} == __UNSET__ ]]; then
       unset NIX_SSL_CERT_FILE
+    else
+      export NIX_SSL_CERT_FILE=${impure_nix_ssl_cert_file}
     fi
   fi
 


### PR DESCRIPTION
Otherwise python does not find any certificates