### PR TITLE
Updated installation guide for home-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ In `$HOME/.config/nixpkgs/home.nix` add
   # ...other config, other config...
 
   programs.direnv.enable = true;
-  programs.direnv.stdlib = ''
-    source ${pkgs.nix-direnv}/share/nix-direnv/direnvrc
-  '';
+  programs.direnv.enableNixDirenvIntegration = true;
 }
 ```
 


### PR DESCRIPTION
Home-manager now supports the option [programs.direnv.enableNixDirenvIntegration](https://rycee.gitlab.io/home-manager/options.html#opt-programs.direnv.enableNixDirenvIntegration).
User does not need to set the `stdlib` option now.