### PR TITLE
use mkdir -p for direnv_layout_dir

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -66,7 +66,7 @@ use_flake() {
      ]];
   then
     local tmp_profile="$(direnv_layout_dir)/flake-profile.$$"
-    [[ -d "$(direnv_layout_dir)" ]] || mkdir "$(direnv_layout_dir)"
+    [[ -d "$(direnv_layout_dir)" ]] || mkdir -p "$(direnv_layout_dir)"
     local tmp_profile_rc=$(nix print-dev-env --profile "$tmp_profile")
     drv=$(realpath "$tmp_profile")
     echo "$tmp_profile_rc" > "$profile_rc"
@@ -130,7 +130,7 @@ use_nix() {
      || shell.nix -nt "$cache"
      ]];
   then
-    [[ -d "$direnv_dir" ]] || mkdir "$direnv_dir"
+    [[ -d "$direnv_dir" ]] || mkdir -p "$direnv_dir"
     local dump_cmd tmp
     dump_cmd="echo -n _____direnv_____; \"$direnv\" dump bash"
     tmp=$(nix-shell --show-trace --pure "$@" --run "$dump_cmd")


### PR DESCRIPTION
This avoids a `cannot create directory` error when a custom layout dir like `direnv_layout_dir=$HOME/.cache/nix-direnv/$pwdHash` is used and the cache dir doesn't exist.
This may happen when nix-direnv is used for the first time or when the cache has been cleared.