### PR TITLE
direnvrc: Fix reading of nixpkgs version from git checkout

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -114,7 +114,7 @@ use_nix() {
     read -r head < "${path}/.git/HEAD"
     local regex="ref: (.*)"
     if [[ "$head" =~  $regex ]]; then
-      read -r version < ".git/${BASH_REMATCH[1]}"
+      read -r version < "${path}/.git/${BASH_REMATCH[1]}"
     else
       version="$head"
     fi


### PR DESCRIPTION
Without this patch, the following error occurs when using a git checkout of nixpkgs:

```
/run/current-system/sw/share/nix-direnv/direnvrc:115: .git/refs/heads/nixos-unstable: No such file or directory
```