### PR TITLE
Force use of GNU Grep (on OSX)

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -121,7 +121,7 @@ use_flake() {
 use_nix() {
   local path layout_dir grep
   path=$("${NIX_BIN_PREFIX}nix-instantiate" --find-file nixpkgs)
-  grep=$("${NIX_BIN_PREFIX}nix-instantiate" -E 'with import <nixpkgs> {}; gnugrep')/bin/grep
+  grep=$("${NIX_BIN_PREFIX}nix-build" -E 'with import <nixpkgs> {}; gnugrep')/bin/grep
   layout_dir=$(direnv_layout_dir)
   local experimental_flags=()
   if nix-shell --experimental-features '' --version 2>/dev/null >&2; then

--- a/direnvrc
+++ b/direnvrc
@@ -119,8 +119,9 @@ use_flake() {
 }
 
 use_nix() {
-  local path layout_dir
+  local path layout_dir grep
   path=$("${NIX_BIN_PREFIX}nix-instantiate" --find-file nixpkgs)
+  grep=$(nix run nixpkgs.gnugrep -c which grep)
   layout_dir=$(direnv_layout_dir)
   local experimental_flags=()
   if nix-shell --experimental-features '' --version 2>/dev/null >&2; then
@@ -162,8 +163,8 @@ use_nix() {
       "${experimental_flags[@]}" \
       --show-trace --pure "$@" --run "$dump_cmd")
     # show original shell hook output
-    echo "$tmp" | grep -vP '(?<=_____direnv_____).*'
-    echo "$tmp" | grep -oP '(?<=_____direnv_____).*' > "$cache"
+    echo "$tmp" | $grep -vP '(?<=_____direnv_____).*'
+    echo "$tmp" | $grep -oP '(?<=_____direnv_____).*' > "$cache"
     update_drv=1
   else
     log_status using cached derivation
@@ -178,7 +179,7 @@ use_nix() {
     local drv_link="${layout_dir}/drv" drv
     drv=$("${NIX_BIN_PREFIX}nix" show-derivation "$out" \
       "${experimental_flags[@]}" \
-      | grep -E -o -m1 '/nix/store/.*.drv')
+      | $grep -E -o -m1 '/nix/store/.*.drv')
     _nix_add_gcroot "$drv" "$drv_link"
     log_status renewed cache and derivation link
   fi

--- a/direnvrc
+++ b/direnvrc
@@ -121,7 +121,7 @@ use_flake() {
 use_nix() {
   local path layout_dir grep
   path=$("${NIX_BIN_PREFIX}nix-instantiate" --find-file nixpkgs)
-  grep=$(nix-shell -p gnugrep --command "which grep")
+  grep=$("${NIX_BIN_PREFIX}nix-instantiate" -E 'with import <nixpkgs> {}; gnugrep')/bin/grep
   layout_dir=$(direnv_layout_dir)
   local experimental_flags=()
   if nix-shell --experimental-features '' --version 2>/dev/null >&2; then

--- a/direnvrc
+++ b/direnvrc
@@ -121,7 +121,7 @@ use_flake() {
 use_nix() {
   local path layout_dir grep
   path=$("${NIX_BIN_PREFIX}nix-instantiate" --find-file nixpkgs)
-  grep=$(nix run nixpkgs.gnugrep -c which grep)
+  grep=$(nix-shell -p gnugrep --command "which grep")
   layout_dir=$(direnv_layout_dir)
   local experimental_flags=()
   if nix-shell --experimental-features '' --version 2>/dev/null >&2; then


### PR DESCRIPTION
If you install nix-direnv using `source_url` (or any way that doesn't use the nix derivation) on OSX, issue #3 still exists. So I added a "hack" that might not be so much of a hack since if the user is installing this they likely have nix, and if you're using the nix derivation, this should resolve to the same version of grep anyway. 