### PR TITLE
Use impure environment for dump command

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -187,7 +187,7 @@ use_nix() {
     dump_cmd="echo _____direnv_____; \"$direnv\" dump bash"
     tmp=$("${NIX_BIN_PREFIX}nix-shell" \
       "${experimental_flags[@]}" \
-      --show-trace --pure "$@" --run "$dump_cmd")
+      --show-trace "$@" --run "$dump_cmd")
     # show original shell hook output
     echo "$tmp" | _nix_extract_direnv >&2 > "$cache"
     update_drv=1


### PR DESCRIPTION
Since `/share` directories of `nativeBuildInputs` are added to `$XDG_DATA_DIRS` (see https://github.com/direnv/direnv/issues/443#issuecomment-777730925), the original `$XDG_DATA_DIRS` variable (i.e. before entering the directory / loading the environment) is completely overwritten by the new one.

This just happens when using `nix-direnv`. The original `use_nix` function by `direnv` does not use `--pure` and works as expected:

```
use_nix() {
  direnv_load nix-shell --show-trace "$@" --run "$(join_args "$direnv" dump)"
  if [[ $# == 0 ]]; then
    watch_file default.nix shell.nix
  fi
}
```

This pull request fixes the issue for me.