### PR TITLE
Avoid pitfall in home-manager config instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ In `$HOME/.config/nixpkgs/home.nix` add
 
   programs.direnv.enable = true;
   programs.direnv.enableNixDirenvIntegration = true;
+  
+  programs.bash.enable = true;
+  # OR
+  programs.zsh.enable = true;
+  # Or any other shell you're using.
 }
 ```
 


### PR DESCRIPTION
When I followed the README, direnv did not get hooked into zsh because I had zsh installed at the system level, rather than enabled in my `home-manager` configuration. I suggest you make it explicit that it must be the case for the `home.nix` changes to work.