### PR TITLE
direnvrc: Add `nix_direnv_version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,12 @@ via home-manager section.
 
 ### Direnv source_url
 
-Put the following line in your .envrc
+Put the following lines in your `.envrc`:
 
 ```bash
-source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/1.2.6/direnvrc" "sha256-jidqAtTK64MJxz1fd394P1RNUZW5Jd8OFgO2nNg2gJU="
+if ! has nix_direnv_version || ! nix_direnv_version 1.2.6; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/1.2.6/direnvrc" "sha256-jidqAtTK64MJxz1fd394P1RNUZW5Jd8OFgO2nNg2gJU="
+fi
 ```
 
 ## Usage example

--- a/direnvrc
+++ b/direnvrc
@@ -1,5 +1,34 @@
 # shellcheck shell=bash
 
+# Usage: nix_direnv_version <version_at_least>
+#
+# Checks that the nix-direnv version is at least as old as <version_at_least>.
+nix_direnv_version() {
+  declare major='1' minor='2' patch='6' # UPDATE(nix-direnv version)
+
+  [[ $1 =~ ^([^+-.]*)(\.?)([^+-.]*)(\.?)([^+-]*)(-?)([^+]*)(\+?)(.*)$ ]]
+  declare -a ver; ver=("${BASH_REMATCH[@]:1}")
+
+  if [[ ( ${ver[0]} != +([0-9]) ) \
+    || ( ${ver[1]} == '.' && ${ver[2]} != +([0-9]) ) \
+    || ( ${ver[3]} == '.' && ${ver[4]} != +([0-9]) ) \
+    || ( ${ver[5]} == '-' && ${ver[6]} != +([0-9A-Za-z-])*(.+([0-9A-Za-z-])) ) \
+    || ( ${ver[7]} == '+' && ${ver[8]} != +([0-9A-Za-z-])*(.+([0-9A-Za-z-])) ) \
+    || ( ( -n ${ver[5]} || -n ${ver[7]} ) && ( -z ${ver[2]} || -z ${ver[4]} ) ) \
+  ]]; then
+    printf '%s\n' "nix-direnv: error v$1 is not a valid semver version" >&2
+    return 1
+  fi
+
+  if [[ ( ${ver[0]} -gt $major ) \
+    || ( ${ver[2]:=0} -gt $minor ) \
+    || ( ${ver[4]:=0} -gt $patch ) \
+  ]]; then
+    printf '%s\n' "nix-direnv: error current version v$major.$minor.$patch is older than the desired version v$1" >&2
+    return 1
+  fi
+}
+
 if [[ -z ${NIX_BIN_PREFIX:-} ]]; then
   NIX_BIN_PREFIX=$(command -v nix-shell)
   NIX_BIN_PREFIX="${NIX_BIN_PREFIX%/*}/"

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -10,14 +10,20 @@ if [[ -z "$version" ]]; then
     echo "USAGE: $0 version" 2>/dev/null
     exit 1
 fi
+[[ $version =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-?)([^+]*)(\+?)(.*)$ ]]
+declare -a ver; ver=("${BASH_REMATCH[@]:1}")
 
 if [[ "$(git symbolic-ref --short HEAD)" != "master" ]]; then
     echo "must be on master branch" 2>/dev/null
     exit 1
 fi
 
-sed -i -e "s!nix-direnv/.*/direnvrc!nix-direnv/${version}/direnvrc!" README.md
-git add README.md
+sed -i README.md \
+    -e 's!\(nix-direnv/\).*\(/direnvrc\)!\1'"${version}"'\2!'
+    -e 's?\( ! nix_direnv_version \)[0-9.]\+\(; \)?\1'"${version}"'\2?'
+sed -i direnvrc \
+    -e 's!\(declare major=\).*\( # UPDATE(nix-direnv version)\)!\1'"${ver[0]@Q} minor=${ver[1]@Q} patch=${ver[2]@Q}"'\2!'
+git add README.md direnvrc
 git commit -m "bump version ${version}"
 git tag -e "${version}"
 


### PR DESCRIPTION
In the style of direnv's `direnv_version`.
https://github.com/direnv/direnv/blob/729fbecd96f3e827575f19497bc01df33395d679/stdlib.go#L1173-L1179

Can be tested for with `has`, e.g. to decide on using `source_url`.