### PR TITLE
use flake: allow optional flake expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ $ echo "use flake" >> .envrc
 $ direnv allow
 ```
 
+Optionally if you do not want flake.nix to be part of the current directory repo,
+you can specify an arbitrary flake expression as parameter such as:
+```console
+use flake ~/myflakes#project
+```
+
 ## Storing .direnv outside the project directory
 
 A `.direnv` directory will be created in each `use_nix` project, which might

--- a/direnvrc
+++ b/direnvrc
@@ -87,8 +87,10 @@ _nix_add_gcroot() {
 }
 
 use_flake() {
-  watch_file flake.nix
-  watch_file flake.lock
+  flake_expr="${1:-.}"
+  flake_dir="${flake_expr%#*}"
+  watch_file "$flake_dir/"flake.nix
+  watch_file "$flake_dir/"flake.lock
 
   local layout_dir
   layout_dir=$(direnv_layout_dir)
@@ -100,8 +102,8 @@ use_flake() {
      || ! -e "$profile_rc"
      || "$HOME/.direnvrc" -nt "$profile_rc"
      || .envrc -nt "$profile_rc"
-     || flake.nix -nt "$profile_rc"
-     || flake.lock -nt "$profile_rc"
+     || "$flake_dir/"flake.nix -nt "$profile_rc"
+     || "$flake_dir/"flake.lock -nt "$profile_rc"
      ]];
   then
     local tmp_profile="${layout_dir}/flake-profile.$$"
@@ -109,7 +111,7 @@ use_flake() {
     local tmp_profile_rc
     tmp_profile_rc=$("${NIX_BIN_PREFIX}nix" print-dev-env \
       --extra-experimental-features "nix-command flakes" \
-      --profile "$tmp_profile")
+      --profile "$tmp_profile" "$flake_expr")
     # macos does not have realpath
     if command -v realpath >/dev/null; then
       drv=$(realpath "$tmp_profile")
@@ -126,7 +128,7 @@ use_flake() {
     mkdir "$flake_inputs"
     flake_input_paths=$("${NIX_BIN_PREFIX}nix" flake archive --json \
       --extra-experimental-features "nix-command flakes" \
-      | grep -E -o '/nix/store/[^"]+')
+      "$flake_dir" | grep -E -o '/nix/store/[^"]+')
     for path in $flake_input_paths; do
       _nix_add_gcroot "$path" "${flake_inputs}/${path##*/}"
     done


### PR DESCRIPTION
This allows using flake.nix out of tree, which is very appreciable
if you develop in a big repository as flake evaluation will copy the
whole git archive to store everytime it changes.


To give a more concrete example, I have my dev environments in /etc/nixos which is stable and relatively small, so I use it with package name argument for ech project e.g. `use flake /etc/nixos#linux` in .envrc with:
 http://cgit.notk.org/asmadeus/nixos-config.git/tree/pkgs/linux/default.nix
loaded from http://cgit.notk.org/asmadeus/nixos-config.git/tree/pkgs/default.nix with callPackage
loaded from http://cgit.notk.org/asmadeus/nixos-config.git/tree/flake.nix as output's packages.x86_64-linux

Using an in-repo flake.nix for linux kernel development/testing didn't really work well; I considered an intermediate directory depth but that's also annoying, this is perfect and caching / watch all work well for me.
(I also made sure the no argument case still works)