### PR TITLE
fix(warn): stdenv.lib missing

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     install -m500 -D direnvrc $out/share/nix-direnv/direnvrc
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A fast, persistent use_nix implementation for direnv";
     homepage    = "https://github.com/nix-community/nix-direnv";
     license     = licenses.mit;


### PR DESCRIPTION
Fixes:

```
nix-direnv on  master [?] 
❯ nix build .#
trace: Warning: `stdenv.lib` is deprecated and will be removed in the next release. Please use `lib` instead. For more information see https://github.com/NixOS/nixpkgs/issues/108938

nix-direnv on  master [?] 
❯ nix --version
nix (Nix) 2.4pre20210601_5985b8b
```