### PR TITLE
chore: add overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,16 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ self.overlay ];
+      };
     in {
       defaultPackage = pkgs.callPackage ./default.nix {};
     }) // {
+      overlay = final: prev: {
+        nix-direnv = final.callPackage ./default.nix { };
+      };
       defaultTemplate = {
         path = ./template;
         description = "nix flake new -t github:Mic92/nix-direnv .";

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,7 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [ self.overlay ];
-      };
+      pkgs = nixpkgs.legacyPackages.${system};
     in {
       defaultPackage = pkgs.callPackage ./default.nix {};
     }) // {


### PR DESCRIPTION
Provide an overlay (and consume it) so that flake users could add a nix module like:

```nix
{
    # ...
    nixosModules = {
        add-overlays = {
            nixpkgs.overlays = [ nix-direnv.overlay ];
            environment.systemPackages = with pkgs; [
                direnv
                nix-direnv
           ];
        };
    };
}
```