### PR TITLE
fix(doc): document how to enable flake support on NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ In `/etc/nixos/configuration.nix`:
   environment.pathsToLink = [
     "/share/nix-direnv"
   ];
+  # if you also want support for flakes (this makes nix-direnv use the
+  # unstable version of nix):
+  nixpkgs.overlays = [
+    (self: super: { nix-direnv = super.nix-direnv.override { enableFlakes = true; }; } )
+  ];
 }
 ```
 


### PR DESCRIPTION
Due to NixOS making nix-direnv use the stable version of nix by
default we get this error when using flakes:

direnv: using flake
error: 'print-dev-env' is not a recognised command
[…]
error: 'flake' is not a recognised command

This can be worked around by passing `enableFlakes = true` to the
package.

See also #92.