### PR TITLE
Add `use_flake_if_supported`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,13 @@ you can specify an arbitrary flake expression as parameter such as:
 use flake ~/myflakes#project
 ```
 
+### Backwards compatibility
+
+If you also provide a `shell.nix` for non-Flakes enabled versions of Nix, you may
+use `use_flake_if_supported` which will automatically fall back to `use_nix` if the
+current Nix version does not support Flakes. In this situation, changes to
+`flake.nix` and `flake.lock` will still automatically trigger a reload.
+
 ## Storing .direnv outside the project directory
 
 A `.direnv` directory will be created in each `use_nix` project, which might

--- a/direnvrc
+++ b/direnvrc
@@ -86,11 +86,34 @@ _nix_add_gcroot() {
   ln -fsn "$symlink" "/nix/var/nix/gcroots/per-user/$USER/$escaped_pwd"
 }
 
+# -n $(_nix_newer_than /path/to/cache /watched1 /watched2 /watched3)
+_nix_newer_than() {
+  local cache=$1
+  shift
+  local watched=("$@")
+  for f in "${watched[@]}"; do
+    if [[ "$f" -nt "$cache" ]]; then
+      echo "1"
+    fi
+  done
+}
+
+# _nix_add_watched /path/to/file
+declare -a _NIX_DIRENV_WATCHED=()
+_nix_add_watched() {
+  watch_file $1
+  _NIX_DIRENV_WATCHED+=($1)
+}
+
+_nix_newer_than_watched() {
+  _nix_newer_than $1 "${_NIX_DIRENV_WATCHED[@]}"
+}
+
 use_flake() {
   flake_expr="${1:-.}"
   flake_dir="${flake_expr%#*}"
-  watch_file "$flake_dir/"flake.nix
-  watch_file "$flake_dir/"flake.lock
+  _nix_add_watched "$flake_dir/"flake.nix
+  _nix_add_watched "$flake_dir/"flake.lock
 
   local layout_dir
   layout_dir=$(direnv_layout_dir)
@@ -102,8 +125,7 @@ use_flake() {
      || ! -e "$profile_rc"
      || "$HOME/.direnvrc" -nt "$profile_rc"
      || .envrc -nt "$profile_rc"
-     || "$flake_dir/"flake.nix -nt "$profile_rc"
-     || "$flake_dir/"flake.lock -nt "$profile_rc"
+     || -n $(_nix_newer_than_watched "$profile_rc")
      ]];
   then
     local tmp_profile="${layout_dir}/flake-profile.$$"
@@ -211,12 +233,16 @@ use_nix() {
 
   local cache="${layout_dir}/cache-${version:-unknown}"
 
+  if [[ "$#" == 0 ]]; then
+    _nix_add_watched default.nix
+    _nix_add_watched shell.nix
+  fi
+
   local update_drv=0
   if [[ ! -e "$cache"
      || "$HOME/.direnvrc" -nt "$cache"
      || .envrc -nt "$cache"
-     || default.nix -nt "$cache"
-     || shell.nix -nt "$cache"
+     || -n $(_nix_newer_than_watched "$cache")
      ]];
   then
     [[ -d "$layout_dir" ]] || mkdir -p "$layout_dir"
@@ -244,10 +270,5 @@ use_nix() {
       | grep -E -o -m1 '/nix/store/.*.drv')
     _nix_add_gcroot "$drv" "$drv_link"
     log_status renewed cache and derivation link
-  fi
-
-  if [[ "$#" == 0 ]]; then
-    watch_file default.nix
-    watch_file shell.nix
   fi
 }

--- a/direnvrc
+++ b/direnvrc
@@ -109,6 +109,22 @@ _nix_newer_than_watched() {
   _nix_newer_than $1 "${_NIX_DIRENV_WATCHED[@]}"
 }
 
+use_flake_if_supported() {
+  if "${NIX_BIN_PREFIX}nix-shell" --extra-experimental-features '' --version 2>/dev/null >&2; then
+    use_flake "$@"
+  else
+    # fall back to "use nix", but also watch flake.{nix,lock} and reload if they change
+    log_status using legacy nix
+
+    flake_expr="${1:-.}"
+    flake_dir="${flake_expr%#*}"
+    _nix_add_watched "$flake_dir/"flake.nix
+    _nix_add_watched "$flake_dir/"flake.lock
+
+    use_nix
+  fi
+}
+
 use_flake() {
   flake_expr="${1:-.}"
   flake_dir="${flake_expr%#*}"


### PR DESCRIPTION
This PR adds an opportunistic `use_flake_if_supported` loader which will automatically fall back to `use_nix` if the current Nix version does not support Flakes. In this situation, changes to `flake.nix` and `flake.lock` will still automatically trigger a reload.

This is mostly useful when you provide a `shell.nix` (e.g., though [flake-compat](https://github.com/edolstra/flake-compat)) and nix-direnv is loaded with `source_url` so no changes on the user's end are required.

To test:
```

source_url "https://github.com/zhaofengli/nix-direnv/raw/2121c62181130c2295183421afda26d2ea7549ef/direnvrc" "sha256-zcBGwswqqcm6VY7j+TMzUtqwZF3romx7fIxqkiu3XxI="
```