### PR TITLE
Add a suffix to cache file to allow multiple calls to use_nix

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -98,7 +98,7 @@ _nix_argsum_suffix() {
       # degrate gracefully both tools are not present
       return
     fi
-    read checksum _ <<< "$out"
+    read -r checksum _ <<< "$out"
     echo "-$checksum"
   fi
 }
@@ -109,9 +109,9 @@ use_flake() {
   watch_file "$flake_dir/"flake.nix
   watch_file "$flake_dir/"flake.lock
 
-  local layout_dir
+  local layout_dir profile
   layout_dir=$(direnv_layout_dir)
-  local profile="${layout_dir}/flake-profile$(_nix_argsum_suffix "$flake_expr")"
+  profile="${layout_dir}/flake-profile$(_nix_argsum_suffix "$flake_expr")"
   local flake_inputs="${layout_dir}/flake-inputs/"
   local profile_rc="${profile}.rc"
 
@@ -226,7 +226,8 @@ use_nix() {
     version="${version_prefix}-${path:11:16}"
   fi
 
-  local cache="${layout_dir}/cache-${version:-unknown}$(_nix_argsum_suffix "$*")"
+  local cache
+  cache="${layout_dir}/cache-${version:-unknown}$(_nix_argsum_suffix "$*")"
 
   local update_drv=0
   if [[ ! -e "$cache"

--- a/direnvrc
+++ b/direnvrc
@@ -90,10 +90,10 @@ _nix_argsum_suffix() {
   local out checksum
   if [ -n "$1" ]; then
 
-    if has shasum; then
-      out=$(shasum <<< "$1")
-    elif has sha1sum; then
+    if has sha1sum; then
       out=$(sha1sum <<< "$1")
+    elif has shasum; then
+      out=$(shasum <<< "$1")
     else
       # degrate gracefully both tools are not present
       return

--- a/direnvrc
+++ b/direnvrc
@@ -86,10 +86,20 @@ _nix_add_gcroot() {
   ln -fsn "$symlink" "/nix/var/nix/gcroots/per-user/$USER/$escaped_pwd"
 }
 
-_argsum_suffix() {
+_nix_argsum_suffix() {
+  local out checksum
   if [ -n "$1" ]; then
-    echo -n "-"
-    echo "$1" | shasum | cut -d' ' -f1
+
+    if has shasum; then
+      out=$(shasum <<< "$1")
+    elif has sha1sum; then
+      out=$(sha1sum <<< "$1")
+    else
+      # degrate gracefully both tools are not present
+      return
+    fi
+    read checksum _ <<< "$out"
+    echo "-$checksum"
   fi
 }
 
@@ -101,7 +111,7 @@ use_flake() {
 
   local layout_dir
   layout_dir=$(direnv_layout_dir)
-  local profile="${layout_dir}/flake-profile$(_argsum_suffix "$flake_expr")"
+  local profile="${layout_dir}/flake-profile$(_nix_argsum_suffix "$flake_expr")"
   local flake_inputs="${layout_dir}/flake-inputs/"
   local profile_rc="${profile}.rc"
 
@@ -216,7 +226,7 @@ use_nix() {
     version="${version_prefix}-${path:11:16}"
   fi
 
-  local cache="${layout_dir}/cache-${version:-unknown}$(_argsum_suffix "$*")"
+  local cache="${layout_dir}/cache-${version:-unknown}$(_nix_argsum_suffix "$*")"
 
   local update_drv=0
   if [[ ! -e "$cache"

--- a/direnvrc
+++ b/direnvrc
@@ -86,6 +86,13 @@ _nix_add_gcroot() {
   ln -fsn "$symlink" "/nix/var/nix/gcroots/per-user/$USER/$escaped_pwd"
 }
 
+_argsum_suffix() {
+  if [ -n "$1" ]; then
+    echo -n "-"
+    echo "$1" | shasum | cut -d' ' -f1
+  fi
+}
+
 use_flake() {
   flake_expr="${1:-.}"
   flake_dir="${flake_expr%#*}"
@@ -94,7 +101,7 @@ use_flake() {
 
   local layout_dir
   layout_dir=$(direnv_layout_dir)
-  local profile="${layout_dir}/flake-profile"
+  local profile="${layout_dir}/flake-profile$(_argsum_suffix "$flake_expr")"
   local flake_inputs="${layout_dir}/flake-inputs/"
   local profile_rc="${profile}.rc"
 
@@ -209,7 +216,7 @@ use_nix() {
     version="${version_prefix}-${path:11:16}"
   fi
 
-  local cache="${layout_dir}/cache-${version:-unknown}"
+  local cache="${layout_dir}/cache-${version:-unknown}$(_argsum_suffix "$*")"
 
   local update_drv=0
   if [[ ! -e "$cache"


### PR DESCRIPTION
This change permits to make multiple calls to use_nix, with different
arguments passed to it. It will generate a cache file for each distinct
"argument list" rather than based solely on the nixpkgs version.