### PR TITLE
useFlake(): fix sed invocation on legacy operating systems

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -152,7 +152,8 @@ use_flake() {
 
     log_status renewed cache
   else
-    sed -i "/eval \"\$shellHook\"/d" "$profile_rc"
+    sed "/eval \"\$shellHook\"/d" "$profile_rc" > "${profile_rc}.tmp"
+    mv "${profile_rc}.tmp" "${profile_rc}"
     log_status using cached dev shell
   fi
 


### PR DESCRIPTION
macOS has `-i` but it insists on writing backup files.

fixes https://github.com/nix-community/nix-direnv/issues/120