### PR TITLE
flake.nix: Import `shell.nix` as `devShell`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,8 @@
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in {
-      defaultPackage = pkgs.callPackage ./default.nix {};
+      defaultPackage = pkgs.callPackage ./default.nix { };
+      devShell = pkgs.callPackage ./shell.nix { };
     }) // {
       overlay = final: prev: {
         nix-direnv = final.callPackage ./default.nix { };

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,6 @@
-with import <nixpkgs> {};
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
 mkShell {
   nativeBuildInputs = [
     python3


### PR DESCRIPTION
This will make it so that running `nix develop` in this repo is equivalent to `nix-shell`

I'm not sure if this is what we want as it means `nix develop` will no longer have take the phases from `default.nix`