### PR TITLE
remove enableFlake from the doc for home-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In `$HOME/.config/nixpkgs/home.nix` add
 
   programs.direnv.enable = true;
   programs.direnv.nix-direnv.enable = true;
-  # optional for nix flakes support
+  # optional for nix flakes support in home-manager 21.11, not required in home-manager unstable or 22.05
   programs.direnv.nix-direnv.enableFlakes = true;
 
   programs.bash.enable = true;


### PR DESCRIPTION
Remove `nix-direnv.enableFlake` option from the doc as Flake support is now always enabled.

Fixes #131 