### PR TITLE
Allow passing arguments to print-dev-env invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,24 @@ you can specify an arbitrary flake expression as parameter such as:
 use flake ~/myflakes#project
 ```
 
+### Advanced usage
+
+Under the covers, `use_flake` calls `nix print-dev-env`.
+The first argument to the `use_flake` function is the flake expression to use,
+and all other arguments are proxied along to the call to `print-dev-env`.
+You may make use of this fact for some more arcane invocations.
+
+For instance, if you have a flake that needs to be called impurely under some conditions,
+you may wish to pass `--impure` to the `print-dev-env` invocation
+so that the environment of the calling shell is passed in.
+
+You can do that as follows:
+
+```
+$ echo "use flake . --impure" > .envrc
+$ direnv allow
+```
+
 ## Storing .direnv outside the project directory
 
 A `.direnv` directory will be created in each `use_nix` project, which might

--- a/direnvrc
+++ b/direnvrc
@@ -129,7 +129,7 @@ use_flake() {
     local tmp_profile_rc
     tmp_profile_rc=$("${NIX_BIN_PREFIX}nix" print-dev-env \
       --extra-experimental-features "nix-command flakes" \
-      --profile "$tmp_profile" "$flake_expr")
+      --profile "$tmp_profile" $@)
     # macos does not have realpath
     if command -v realpath >/dev/null; then
       drv=$(realpath "$tmp_profile")

--- a/direnvrc
+++ b/direnvrc
@@ -129,7 +129,7 @@ use_flake() {
     local tmp_profile_rc
     tmp_profile_rc=$("${NIX_BIN_PREFIX}nix" print-dev-env \
       --extra-experimental-features "nix-command flakes" \
-      --profile "$tmp_profile" $@)
+      --profile "$tmp_profile" "$@")
     # macos does not have realpath
     if command -v realpath >/dev/null; then
       drv=$(realpath "$tmp_profile")


### PR DESCRIPTION
Closes #135.

The fix here is simple. The arguments passed to `use_flake` are already an array.
Assuming that the first entry in that array is a flake specifier is still fine,
but this change allows us to fill the rest of the array with  other arguments to pass to `print-dev-env`.

I don't anticipate this being completely finalized, as tests should be built for this functionality (though I am unsure how right now) and the documentation should be updated to reflect the change. 

This is open for discussion as I am unsure if this is a change that the maintainers generally want.