### PR TITLE
Declare (and enforce) a minimum direnv version

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -5,7 +5,7 @@
 # Checks that the nix-direnv version is at least as old as <version_at_least>.
 
 if ! has direnv_version || ! direnv_version 2.21.3; then
-  exit
+  exit 1
 fi
 
 nix_direnv_version() {

--- a/direnvrc
+++ b/direnvrc
@@ -3,6 +3,11 @@
 # Usage: nix_direnv_version <version_at_least>
 #
 # Checks that the nix-direnv version is at least as old as <version_at_least>.
+
+if ! has direnv_version || ! direnv_version 2.21.3; then
+  exit
+fi
+
 nix_direnv_version() {
   declare major='1' minor='5' patch='1' # UPDATE(nix-direnv version)
 

--- a/direnvrc
+++ b/direnvrc
@@ -1,13 +1,16 @@
 # shellcheck shell=bash
 
-# Usage: nix_direnv_version <version_at_least>
-#
-# Checks that the nix-direnv version is at least as old as <version_at_least>.
+REQUIRED_DIRENV_VERSION="2.21.3"
 
-if ! has direnv_version || ! direnv_version 2.21.3; then
+
+if ! has direnv_version || ! direnv_version "$REQUIRED_DIRENV_VERSION" 2>/dev/null; then
+  printf '%s\n' "nix-direnv: base direnv version is older than the required v$REQUIRED_DIRENV_VERSION." >&2
   exit 1
 fi
 
+# Usage: nix_direnv_version <version_at_least>
+#
+# Checks that the nix-direnv version is at least as old as <version_at_least>.
 nix_direnv_version() {
   declare major='1' minor='5' patch='1' # UPDATE(nix-direnv version)
 


### PR DESCRIPTION
2.21.3 introduces extglob to direnv's stdlib.
This means we need at least 2.21.3 to execute nix_direnv_version.
This just enforces a previously unstated dependency.

The other possible solution is to directly call `shopt -s extglob` in `nix_direnv_version`,
but I'm afraid of that having effects in other places OR of nix-direnv depending on other post-direnv-2.21.3-isms.

Part of #139 