### PR TITLE
Release version 1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ via home-manager section.
 Put the following lines in your `.envrc`:
 
 ```bash
-if ! has nix_direnv_version || ! nix_direnv_version 1.6.0; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/1.6.0/direnvrc" "sha256-FqqbUyxL8MZdXe5LkMgtNo95raZFbegFpl5k2+PrCow="
+if ! has nix_direnv_version || ! nix_direnv_version 1.6.1; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/1.6.1/direnvrc" "sha256-P2S98+KgnN3WN+MPDY5wpg5Cqu3VYhxiCZH09cD88z8="
 fi
 ```
 

--- a/direnvrc
+++ b/direnvrc
@@ -12,7 +12,7 @@ fi
 #
 # Checks that the nix-direnv version is at least as old as <version_at_least>.
 nix_direnv_version() {
-  declare major='1' minor='6' patch='0' # UPDATE(nix-direnv version)
+  declare major='1' minor='6' patch='1' # UPDATE(nix-direnv version)
 
   [[ $1 =~ ^([^+-.]*)(\.?)([^+-.]*)(\.?)([^+-]*)(-?)([^+]*)(\+?)(.*)$ ]]
   declare -a ver; ver=("${BASH_REMATCH[@]:1}")

--- a/template/.envrc
+++ b/template/.envrc
@@ -1,4 +1,4 @@
-if ! has nix_direnv_version || ! nix_direnv_version 1.6.0; then
-    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/1.6.0/direnvrc" "sha256-FqqbUyxL8MZdXe5LkMgtNo95raZFbegFpl5k2+PrCow="
+if ! has nix_direnv_version || ! nix_direnv_version 1.6.1; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/1.6.1/direnvrc" "sha256-P2S98+KgnN3WN+MPDY5wpg5Cqu3VYhxiCZH09cD88z8="
 fi
 use flake


### PR DESCRIPTION
* Update hashes
  * Hash obtained via:
    ```sh
    direnv fetchurl 'https://raw.githubusercontent.com/nix-community/nix-direnv/master/direnvrc' \
      | grep -m1 -o 'sha256-.*'
    ```
* Bump tag to 1.6.1 in:
  * `README.md`
  * `direnvrc`
  * `template/.envrc`

This release includes the following changes:

* Allow watching of arbitrary files for nix flake updates ([#148][1])

[1]: https://github.com/nix-community/nix-direnv/pull/148