### PR TITLE
Fix path and package handling in use_nix arg parsing

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -284,7 +284,7 @@ use_nix() {
         shift
         shift
         ;;
-      -*)
+      *)
         if [[ $in_packages == 1 ]]; then
           packages+=" $i"
         else


### PR DESCRIPTION
Neither `in_packages` nor `nixfile` should require prefixing with a `-`.