### PR TITLE
Ensure extra arguments passed to shell

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -313,7 +313,6 @@ use_nix() {
   then
     local tmp_profile="${layout_dir}/flake-profile.$$"
     local tmp_profile_rc
-    local extra_args=()
 
     if [[ "$packages" != "" ]]; then
       extra_args+=("--expr" "with import <nixpkgs> {}; mkShell { buildInputs = [ $packages ]; }")


### PR DESCRIPTION
Extra arguments passed to `use nix` (such as `--arg` or `--argstr`)
were getting clobbered by an errant re-definition. Removed that
definition so those arguments get passed along.

Due to #190 