### PR TITLE
Fix error with strict_env

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -100,7 +100,7 @@ _nix_import_env() {
   # as it may be garbage collected.
   # Instead - just remove it immediately.
   # Use recursive & force as it may not be empty.
-  if [[ "$NIX_BUILD_TOP" == */nix-shell.* && -d "$NIX_BUILD_TOP" ]]; then
+  if [[ -n "${NIX_BUILD_TOP+x}" && "$NIX_BUILD_TOP" == */nix-shell.* && -d "$NIX_BUILD_TOP" ]]; then
     rm -rf "$NIX_BUILD_TOP"
   fi
 


### PR DESCRIPTION
With direnv’s `strict_env`, previously got an error

> NIX_BUILD_TOP: unbound variable

I tried to adjust the tests to catch this, but unfortunately I could not
get them to fail as-is.

Maybe fixes #128, though that also makes me question if this is the best solution to the problem, or just a workaround.