### PR TITLE
Replace deprecated devShell attribute key

### DIFF
--- a/templates/flake/flake.nix
+++ b/templates/flake/flake.nix
@@ -7,7 +7,7 @@
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in {
-      devShell = pkgs.mkShell {
+      devShells.default = pkgs.mkShell {
         nativeBuildInputs = [ pkgs.bashInteractive ];
         buildInputs = [ ];
       };


### PR DESCRIPTION
Running `nix flake check` on a flake created using this template results in the following warning:

> warning: flake output attribute 'devShell' is deprecated; use 'devShells.\<system\>.default' instead

This PR updates the flake template accordingly.