### PR TITLE
remove old gcroots when the environment is updated

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -112,15 +112,31 @@ _nix_import_env() {
   export XDG_DATA_DIRS=$XDG_DATA_DIRS${old_xdg_data_dirs:+":"}$old_xdg_data_dirs
 }
 
+_nix_strip_escape_path() {
+  local stripped_path=${1/\//}
+  local escaped_path=${stripped_path//-/--}
+  local escaped_path=${escaped_path//\//-}
+
+  echo "$escaped_path"
+}
+
 _nix_add_gcroot() {
   local storepath=$1
   local symlink=$2
+  local escaped_symlink
+  escaped_symlink=$(_nix_strip_escape_path "$symlink")
 
-  local stripped_pwd=${2/\//}
-  local escaped_pwd=${stripped_pwd//-/--}
-  local escaped_pwd=${escaped_pwd//\//-}
   ln -fsn "$storepath" "$symlink"
-  ln -fsn "$symlink" "/nix/var/nix/gcroots/per-user/$USER/$escaped_pwd"
+  ln -fsn "$symlink" "/nix/var/nix/gcroots/per-user/$USER/$escaped_symlink"
+}
+
+_nix_clean_old_gcroots() {
+  local layout_dir=$1
+  local escaped_layout_dir
+  escaped_layout_dir=$(_nix_strip_escape_path "$layout_dir")
+
+  rm -fv "$layout_dir"/nix-{flake,profile}*
+  rm -fv "/nix/var/nix/gcroots/per-user/$USER/$escaped_layout_dir"--nix--{profile,flake}*
 }
 
 _nix_argsum_suffix() {
@@ -180,6 +196,8 @@ use_flake() {
      || "$need_update" == "1"
      ]];
   then
+    _nix_clean_old_gcroots "$layout_dir"
+
     # We need to update our cache
     local tmp_profile="${layout_dir}/flake-profile.$$"
     local tmp_profile_rc
@@ -204,6 +222,7 @@ use_flake() {
       --no-write-lock-file \
       "$flake_dir" | grep -E -o '/nix/store/[^"]+')
     for path in $flake_input_paths; do
+      _nix_clean_old_gcroots "$flake_inputs"
       _nix_add_gcroot "$path" "${flake_inputs}/${path##*/}"
     done
 
@@ -322,6 +341,8 @@ use_nix() {
      || "$need_update" -eq "1"
      ]];
   then
+    _nix_clean_old_gcroots "$layout_dir"
+
     local tmp_profile="${layout_dir}/flake-profile.$$"
     local tmp_profile_rc
 

--- a/direnvrc
+++ b/direnvrc
@@ -135,8 +135,8 @@ _nix_clean_old_gcroots() {
   local escaped_layout_dir
   escaped_layout_dir=$(_nix_strip_escape_path "$layout_dir")
 
-  rm -fv "$layout_dir"/nix-{flake,profile}*
-  rm -fv "/nix/var/nix/gcroots/per-user/$USER/$escaped_layout_dir"--nix--{profile,flake}*
+  rm -fv "$layout_dir"/{nix,flake}-profile*
+  rm -fv "/nix/var/nix/gcroots/per-user/$USER/$escaped_layout_dir"--{nix,flake}--profile*
 }
 
 _nix_argsum_suffix() {

--- a/direnvrc
+++ b/direnvrc
@@ -135,7 +135,7 @@ _nix_clean_old_gcroots() {
   local escaped_layout_dir
   escaped_layout_dir=$(_nix_strip_escape_path "$layout_dir")
 
-  rm -rfv "$layout_dir/flake_inputs/"
+  rm -rfv "$layout_dir/flake-inputs/"
   rm -fv "$layout_dir"/{nix,flake}-profile*
   rm -fv "/nix/var/nix/gcroots/per-user/$USER/$escaped_layout_dir"-flake--inputs*
   rm -fv "/nix/var/nix/gcroots/per-user/$USER/$escaped_layout_dir"-{nix,flake}--profile*

--- a/direnvrc
+++ b/direnvrc
@@ -135,8 +135,10 @@ _nix_clean_old_gcroots() {
   local escaped_layout_dir
   escaped_layout_dir=$(_nix_strip_escape_path "$layout_dir")
 
+  rm -rfv "$layout_dir/flake_inputs/"
   rm -fv "$layout_dir"/{nix,flake}-profile*
-  rm -fv "/nix/var/nix/gcroots/per-user/$USER/$escaped_layout_dir"--{nix,flake}--profile*
+  rm -fv "/nix/var/nix/gcroots/per-user/$USER/$escaped_layout_dir"-flake--inputs*
+  rm -fv "/nix/var/nix/gcroots/per-user/$USER/$escaped_layout_dir"-{nix,flake}--profile*
 }
 
 _nix_argsum_suffix() {
@@ -214,7 +216,6 @@ use_flake() {
 
     # also add garbage collection root for source
     local flake_input_paths
-    rm -rf "$flake_inputs"
     mkdir "$flake_inputs"
     flake_input_paths=$("${NIX_BIN_PREFIX}nix" flake archive \
       --json \
@@ -222,7 +223,6 @@ use_flake() {
       --no-write-lock-file \
       "$flake_dir" | grep -E -o '/nix/store/[^"]+')
     for path in $flake_input_paths; do
-      _nix_clean_old_gcroots "$flake_inputs"
       _nix_add_gcroot "$path" "${flake_inputs}/${path##*/}"
     done
 

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -64,7 +64,9 @@ def test_use_nix(direnv_project: DirenvProject) -> None:
     direnv_project.setup_envrc("use nix")
     common_test(direnv_project)
 
-    direnv_project.setup_envrc("use nix --argstr 'echo Executing hijacked shellHook.'")
+    direnv_project.setup_envrc(
+        "use nix --argstr shellHook 'echo Executing hijacked shellHook.'"
+    )
     common_test_clean(direnv_project)
 
 

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -64,8 +64,7 @@ def test_use_nix(direnv_project: DirenvProject) -> None:
     direnv_project.setup_envrc("use nix")
     common_test(direnv_project)
 
-    # --pure here is just a way to make sure the environment changes
-    direnv_project.setup_envrc("use nix --pure")
+    direnv_project.setup_envrc("use nix --argstr 'echo Executing hijacked shellHook.'")
     common_test_clean(direnv_project)
 
 
@@ -81,7 +80,6 @@ def test_use_flake(direnv_project: DirenvProject) -> None:
     for symlink in inputs:
         assert symlink.is_dir()
 
-    # --impure here is just a way to make sure the environment changes
     direnv_project.setup_envrc("use flake --impure")
     common_test_clean(direnv_project)
 

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -56,8 +56,6 @@ def common_test_clean(direnv_project: DirenvProject) -> None:
     profiles = [f for f in files if not f.match("*.rc")]
     if len(rcs) != 1 or len(profiles) != 1:
         print(list(files))
-    print(list(files))
-    assert False
     assert len(rcs) == 1
     assert len(profiles) == 1
 
@@ -83,8 +81,6 @@ def test_use_flake(direnv_project: DirenvProject) -> None:
     for symlink in inputs:
         assert symlink.is_dir()
 
-    files = list((direnv_project.dir / ".direnv").iterdir())
-    print(files)
     # --impure here is just a way to make sure the environment changes
     direnv_project.setup_envrc("use flake --impure")
     common_test_clean(direnv_project)

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -55,7 +55,7 @@ def common_test_clean(direnv_project: DirenvProject) -> None:
     rcs = [f for f in files if f.match("*.rc")]
     profiles = [f for f in files if not f.match("*.rc")]
     if len(rcs) != 1 or len(profiles) != 1:
-        print(list(files))
+        print(files)
     assert len(rcs) == 1
     assert len(profiles) == 1
 

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -56,6 +56,8 @@ def common_test_clean(direnv_project: DirenvProject) -> None:
     profiles = [f for f in files if not f.match("*.rc")]
     if len(rcs) != 1 or len(profiles) != 1:
         print(list(files))
+    print(list(files))
+    assert False
     assert len(rcs) == 1
     assert len(profiles) == 1
 
@@ -83,8 +85,8 @@ def test_use_flake(direnv_project: DirenvProject) -> None:
 
     files = list((direnv_project.dir / ".direnv").iterdir())
     print(files)
-    # -ignore-environment here is just a way to make sure the environment changes
-    direnv_project.setup_envrc("use flake")
+    # --impure here is just a way to make sure the environment changes
+    direnv_project.setup_envrc("use flake --impure")
     common_test_clean(direnv_project)
 
 

--- a/tests/testenv/shell.nix
+++ b/tests/testenv/shell.nix
@@ -1,14 +1,11 @@
-{ pkgs ? import <nixpkgs> {}, someArg ? null }:
+{ pkgs ? import <nixpkgs> { }, someArg ? null, shellHook ? ''
+  echo "Executing shellHook."
+'' }:
 pkgs.mkShellNoCC {
+  inherit shellHook;
+
   nativeBuildInputs = [ pkgs.hello ];
-  shellHook = ''
-    echo "Executing shellHook."
-  '';
   SHOULD_BE_SET = someArg;
 
-  passthru = {
-    subshell = pkgs.mkShellNoCC {
-      THIS_IS_A_SUBSHELL = "OK";
-    };
-  };
+  passthru = { subshell = pkgs.mkShellNoCC { THIS_IS_A_SUBSHELL = "OK"; }; };
 }


### PR DESCRIPTION
As discussed in #235, nix-direnv currently does not remove the profiles and GC roots created for older version of the environment. This PR aims to fix this.

It adds a function `_nix_clean_old_gcroots` that is called before updating the environment and removes all the `nix-{flake,profile}*` from the local `.direnv` directory as well as the corresponding GC roots. Since this function reuses the code of `_nix_add_gcroots` for escaping path, this code is now run by calling the `_nix_strip_escape_path` function.

I only tested this PR with the current test-suite as I didn't take the time to understand what the tests were doing. Let me know if you want me to add some tests.
