### PR TITLE
fix: render `###`s as `<h3>`s in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ There are different ways to install nix-direnv, pick your favourite:
 
 <details>
   <summary> Via home-manager (Recommended)</summary>
+
 ### Via home-manager
 
 Note that while the home-manager integration is recommended,
@@ -153,6 +154,7 @@ as described in the installation via home-manager section.
 
 <details>
   <summary>From source</summary>
+
 ### From source
 
 Clone the repository to some directory


### PR DESCRIPTION
GitHub renders 
```md
<details>
  <summary>...</summary>
### ...
```
as
```html
<details><summary>...</summary>
### ...
```
but renders
```md
<details>
  <summary>...</summary>

### ...
```
as
```html
<details><summary>...</summary>
<h3>...</h3>
```
which is more likely to be what the authors of the README.md intended.