### PR TITLE
make gcroot cleanup less verbose

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -135,10 +135,10 @@ _nix_clean_old_gcroots() {
   local escaped_layout_dir
   escaped_layout_dir=$(_nix_strip_escape_path "$layout_dir")
 
-  rm -rfv "$layout_dir/flake-inputs/"
-  rm -fv "$layout_dir"/{nix,flake}-profile*
-  rm -fv "/nix/var/nix/gcroots/per-user/$USER/$escaped_layout_dir"-flake--inputs*
-  rm -fv "/nix/var/nix/gcroots/per-user/$USER/$escaped_layout_dir"-{nix,flake}--profile*
+  rm -rf "$layout_dir/flake-inputs/"
+  rm -f "$layout_dir"/{nix,flake}-profile*
+  rm -f "/nix/var/nix/gcroots/per-user/$USER/$escaped_layout_dir"-flake--inputs*
+  rm -f "/nix/var/nix/gcroots/per-user/$USER/$escaped_layout_dir"-{nix,flake}--profile*
 }
 
 _nix_argsum_suffix() {


### PR DESCRIPTION
If you have a few more flakes this will spam your screen with a lot of text.