### PR TITLE
ensure XDG_DATA_DIRS contains unique entries

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -113,7 +113,16 @@ _nix_import_env() {
   _nix_export_or_unset TMPDIR "$old_tmpdir"
   _nix_export_or_unset TEMP "$old_temp"
   _nix_export_or_unset TEMPDIR "$old_tempdir"
-  export XDG_DATA_DIRS=$XDG_DATA_DIRS${old_xdg_data_dirs:+":"}$old_xdg_data_dirs
+  local new_xdg_data_dirs=${XDG_DATA_DIRS:-}
+  export XDG_DATA_DIRS=
+  local IFS=:
+  for dir in $new_xdg_data_dirs${old_xdg_data_dirs:+:}$old_xdg_data_dirs; do
+    dir="${dir%/}" # remove trailing slashes
+    if [[ :$XDG_DATA_DIRS: = *:$dir:* ]]; then
+      continue # already present, skip
+    fi
+    XDG_DATA_DIRS="$XDG_DATA_DIRS${XDG_DATA_DIRS:+:}$dir"
+  done
 }
 
 _nix_strip_escape_path() {


### PR DESCRIPTION
after importing from the nix environment
we currently concatenate the new and old values of XDG_DATA_DIRS,
which means if the nix environment reused or recreated the old values
they are now present twice.
XDG_DATA_DIRS is specified to be a "set",
and some software (GNOME for example) assume that its entries are unique.

this change reconstructs XDG_DATA_DIRS
by looping over the new and old entries
and adding the new ones among them.
it normalizes the entries by removing trailing slashes
to make duplicate detection a bit easier.

it could instead loop over only the old entries and append them to the new ones,
that would save one line of code but make duplicate detection a bit more involved.

looping only over the new entries would make invert their order.