### PR TITLE
Don't track $nixfile if it is empty

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -337,7 +337,7 @@ use_nix() {
   done
 
   nix_direnv_watch_file "$HOME/.direnvrc" "$HOME/.config/direnv/direnvrc" ".envrc"
-  if [ -e "$nixfile" ]; then
+  if [ -f "$nixfile" ]; then
     nix_direnv_watch_file "$nixfile"
   fi
 

--- a/direnvrc
+++ b/direnvrc
@@ -336,9 +336,10 @@ use_nix() {
     esac
   done
 
-  # nixfile may be empty,
-  # but nix_direnv_watch_file checks for existence before adding to watches
-  nix_direnv_watch_file "$HOME/.direnvrc" "$HOME/.config/direnv/direnvrc" .envrc "$nixfile"
+  nix_direnv_watch_file "$HOME/.direnvrc" "$HOME/.config/direnv/direnvrc" ".envrc"
+  if [ -e "$nixfile" ]; then
+    nix_direnv_watch_file "$nixfile"
+  fi
 
   local need_update=0
   local file=

--- a/tests/direnv_project.py
+++ b/tests/direnv_project.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
-from dataclasses import dataclass
 import shutil
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Iterator
-from pathlib import Path
 
 import pytest
 
@@ -21,12 +22,13 @@ class DirenvProject:
         return self.dir / ".envrc"
 
     def setup_envrc(self, content: str) -> None:
-        self.envrc.write_text(
+        text = textwrap.dedent(
             f"""
-source {self.nix_direnv}
-{content}
+        source {self.nix_direnv}
+        {content}
         """
         )
+        self.envrc.write_text(text)
         run(["direnv", "allow"], cwd=self.dir)
 
 

--- a/tests/test_use_nix.py
+++ b/tests/test_use_nix.py
@@ -35,7 +35,15 @@ def test_args(direnv_project: DirenvProject) -> None:
 
 def test_no_files(direnv_project: DirenvProject) -> None:
     direnv_project.setup_envrc("use nix -p hello")
-    direnv_exec(direnv_project, "hello")
+    out = run(
+        ["direnv", "status"],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        check=False,
+        cwd=direnv_project.dir,
+    )
+    assert out.returncode == 0
+    assert 'Loaded watch: "."' not in out.stdout
 
 
 if __name__ == "__main__":

--- a/tests/test_use_nix.py
+++ b/tests/test_use_nix.py
@@ -33,5 +33,10 @@ def test_args(direnv_project: DirenvProject) -> None:
     direnv_exec(direnv_project, "echo $SHOULD_BE_SET")
 
 
+def test_no_files(direnv_project: DirenvProject) -> None:
+    direnv_project.setup_envrc("use nix -p hello")
+    direnv_exec(direnv_project, "hello")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Should resolve #270.

I want to make sure the tests pass before we merge, but the fix is pretty trivial