### PR TITLE
Only archive flake inputs excluding `self` when registering flake inputs as gcroots

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -230,6 +230,7 @@ use_flake() {
     # also add garbage collection root for source
     local flake_input_paths
     mkdir "$flake_inputs"
+    # shellcheck disable=SC2016
     flake_input_paths=$("${NIX_BIN_PREFIX}nix" eval \
       --impure --json --expr \
       'builtins.mapAttrs (_: { outPath, ... }: "${outPath}") (builtins.getFlake (toString ./.)).inputs' \

--- a/direnvrc
+++ b/direnvrc
@@ -230,11 +230,11 @@ use_flake() {
     # also add garbage collection root for source
     local flake_input_paths
     mkdir "$flake_inputs"
-    flake_input_paths=$("${NIX_BIN_PREFIX}nix" flake archive \
-      --json \
-      --extra-experimental-features "nix-command flakes" \
+    flake_input_paths=$("${NIX_BIN_PREFIX}nix" eval \
+      --impure --json --expr \
+      'builtins.mapAttrs (_: { outPath, ... }: "${outPath}") (builtins.getFlake (toString ./.)).inputs' \
       --no-write-lock-file \
-      "$flake_dir" | grep -E -o '/nix/store/[^"]+')
+      --extra-experimental-features "nix-command flakes" | jq '.[]' -r)
     for path in $flake_input_paths; do
       _nix_add_gcroot "$path" "${flake_inputs}/${path##*/}"
     done

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -74,11 +74,11 @@ def test_use_flake(direnv_project: DirenvProject) -> None:
     direnv_project.setup_envrc("use flake")
     common_test(direnv_project)
     inputs = list((direnv_project.dir / ".direnv/flake-inputs").iterdir())
-    # should only contain our flake-utils flake
-    if len(inputs) != 3:
+    # should only contain our flake-utils & nixpkgs flake
+    if len(inputs) != 2:
         run(["nix", "flake", "archive", "--json"], cwd=direnv_project.dir)
         print(inputs)
-    assert len(inputs) == 3
+    assert len(inputs) == 2
     for symlink in inputs:
         assert symlink.is_dir()
 


### PR DESCRIPTION
NOTE: this should probably include a check on whether Nix is new enough to support lazy trees, but for now that's just WIP.

From my understanding we only need the flake's input path itself because Nix would copy it into the store anyways when evaluating a flake. However that's not the case anymore when using the lazy-trees branch (so neither Nix master nor a Nix release).

This change came from the motivation to not have my flakes in my store unless I explicitly need it. This is because flakes contain secrets in my case (these are encrypted via git-crypt, so not leaked in the remote repo), but they're readable by my user in my git checkout. When copying this flake into my local store, my local store makes these secrets available for each user & process on my system which is not nice (even though it's not the end of the world in my case because it's a single-user machine). However I'd like to avoid that and now I can by using lazy-trees, this change is just the last bit to achieve this.