### PR TITLE
Prefer `packages` over `nativeBuildInputs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Either add `shell.nix` or a `default.nix` to the project directory:
 { pkgs ? import <nixpkgs> {}}:
 
 pkgs.mkShell {
-  nativeBuildInputs = [ pkgs.hello ];
+  packages = [ pkgs.hello ];
 }
 ```
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,4 @@
 cut_body_after = "" # don't include text from the PR body in the merge commit message
-status = [ "tests" ]
+status = [
+  "tests (ubuntu-latest)"
+]

--- a/templates/flake/flake.nix
+++ b/templates/flake/flake.nix
@@ -8,8 +8,7 @@
       pkgs = nixpkgs.legacyPackages.${system};
     in {
       devShells.default = pkgs.mkShell {
-        nativeBuildInputs = [ pkgs.bashInteractive ];
-        buildInputs = [ ];
+        packages = [ pkgs.bashInteractive ];
       };
     });
 }


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/commit/c6b62f2381571cc83c6c32ef4984fabcbb4ca892 we now have the `packages` attribute which at least in the nixpkgs repository seems to be preferred over `nativeBuildInputs` in the `mkShell` context. 

I also removed the empty `buildInputs` attribute. These two changes makes the template a bit more beginner-friendly in my opinion and aligns it with the documentation on `pkgs.mkShell`: https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell

