### PR TITLE
source_url install: fix hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Put the following lines in your `.envrc`:
 
 ```bash
 if ! has nix_direnv_version || ! nix_direnv_version 2.2.1; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.1/direnvrc" "sha256-5EwyKnkJNQeXrRkYbwwRBcXbibosCJqyIUuz9Xq+LRc="
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.1/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
 fi
 ```
 


### PR DESCRIPTION
The version has been updated (from 2.2.0 to 2.2.1) but the hash has not been updated, resulting in the following error

direnv: error hash mismatch. Expected 'sha256-5EwyKnkJNQeXrRkYbwwRBcXbibosCJqyIUuz9Xq+LRc=' but got 'sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs='