### PR TITLE
Fix reading nixpkgs version without trailing newline

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -272,7 +272,7 @@ use_nix() {
     elif [[ -f "${path}/.version" && "${path}" == "/nix/store/"* ]]; then
       # borrow some bits from the store path
       local version_prefix
-      read -r version_prefix < "${path}/.version"
+      read -r version_prefix < <(cat "${path}/.version" ; echo)
       version="${version_prefix}-${path:11:16}"
     fi
   fi


### PR DESCRIPTION
`read` fails if it encounters EOF before the delim, the `.version` file does not always have a newline, so `read` fails in that case. If the env has `set -e` then this will abort. So add a newline to the end always. Doesn’t seem to matter if there is more than one.