### PR TITLE
Check nix version directly

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -27,7 +27,7 @@ _nix_direnv_preflight () {
   nixversion=$("${NIX_BIN_PREFIX}"nix --version)
   [[ "$nixversion" =~ ([0-9]+)[^0-9]*([0-9]+)[^0-9]*([0-9]+)? ]]
   if [[ "${BASH_REMATCH[1]}" -lt "2" || "${BASH_REMATCH[1]}" -eq "2" && "${BASH_REMATCH[2]}" -lt "4" ]]; then
-    log_status "nix-direnv: nix version is older than the required 2.4."
+    log_status "nix-direnv: nix version ${BASH_REMATCH[0]} is older than the required 2.4."
     exit 1
   fi
 

--- a/direnvrc
+++ b/direnvrc
@@ -24,7 +24,9 @@ _nix_direnv_preflight () {
     exit 1
   fi
 
-  if ! "${NIX_BIN_PREFIX}nix-shell" --extra-experimental-features '' --version 2>/dev/null >&2; then
+  nixversion=$("${NIX_BIN_PREFIX}"nix --version)
+  [[ "$nixversion" =~ ([0-9]+)[^0-9]*([0-9]+)[^0-9]*([0-9]+)? ]]
+  if [[ "${BASH_REMATCH[1]}" -lt "2" || "${BASH_REMATCH[1]}" -eq "2" && "${BASH_REMATCH[2]}" -lt "4" ]]; then
     log_status "nix-direnv: nix version is older than the required 2.4."
     exit 1
   fi


### PR DESCRIPTION
This PR resolves issue #305 by querying the nix version through ``nix --version`` and testing that.

It also adds error reporting of the current nix version in case the test fails.