### PR TITLE
Fix use nix with no nixpkgs when strict_env

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -256,7 +256,7 @@ use_nix() {
 
   local layout_dir path version
   layout_dir=$(direnv_layout_dir)
-  path=$("${NIX_BIN_PREFIX}nix-instantiate" --find-file nixpkgs 2>/dev/null)
+  path=$("${NIX_BIN_PREFIX}nix-instantiate" --find-file nixpkgs 2>/dev/null || true)
   if [[ -n "$path" ]]; then
     path=$(_nix_direnv_realpath "$path")
 


### PR DESCRIPTION
strict_env basically does `set -e`, and this fails in that case. We handle it failing in the `if` on the subsequent line.

I’m curious if `setup_envrc` in the tests should be changed to set `strict_env` to catch this sort of thing—or maybe parameterize all the tests over both cases?