### PR TITLE
Apply all arguments to `nix flake archive` command

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -222,7 +222,7 @@ use_flake() {
       --json \
       --extra-experimental-features "nix-command flakes" \
       --no-write-lock-file \
-      "$flake_dir" | grep -E -o '/nix/store/[^"]+')
+      "$@" | grep -E -o '/nix/store/[^"]+')
     for path in $flake_input_paths; do
       _nix_add_gcroot "$path" "${flake_inputs}/${path##*/}"
     done


### PR DESCRIPTION
In Repl.it, I want to disable downloading the source from online so I use the following code inside `.envrc`.

`use flake .# "--override-input" "nixpkgs" "git+file:./nixpkgs?shallow=1"`

This code allows the `nix flake archive` part of `use_flake` function to respect the arguments given.