### PR TITLE
Warn when `use flake` receives a flag for the first argument

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -195,7 +195,7 @@ use_flake() {
   flake_expr="${1:-.}"
   flake_dir="${flake_expr%#*}"
 
-  if [[ "$flake_expr" =~ ^-[^#]*$ ]]; then
+  if [[ "$flake_expr" = -* ]]; then
     if [[ -n "$2" ]]; then
       log_status "nix-direnv: the first argument must be a flake expression"
     else

--- a/direnvrc
+++ b/direnvrc
@@ -195,6 +195,14 @@ use_flake() {
   flake_expr="${1:-.}"
   flake_dir="${flake_expr%#*}"
 
+  if [[ "$flake_expr" =~ ^-[^#]*$ ]]; then
+    if [[ -n "$2" ]]; then
+      log_status "nix-direnv: the first argument must be a flake expression"
+    else
+      log_status "nix-direnv: the first argument must be a flake expression. did you mean 'use flake . $1'?"
+    fi
+  fi
+
   local files_to_watch
   files_to_watch=(".envrc" "$HOME/.direnvrc" "$HOME/.config/direnv/direnvrc")
 


### PR DESCRIPTION
This bit me recently. Usually `use flake -L` and `use flake -L some-flake` work without errors. When an error does occur, the resulting error messages can be obscure.
