### PR TITLE
update README... again

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ other available options are:
   programs.direnv = {
     package = pkgs.direnv;
     silent = false;
-    persistDerivations = true;
     loadInNixShell = true;
     direnvrcExtra = "";
     nix-direnv = {
@@ -107,14 +106,6 @@ other available options are:
     };
   }
 ```
-
-and sourcing the `direnvrc` from this repository in your own `$HOME/.config/direnv/direnvrc`
-
-```bash
-# put this in ~/.config/direnv/direnvrc
-source /run/current-system/sw/share/nix-direnv/direnvrc
-```
-
 </details>
 
 <details>


### PR DESCRIPTION
The nixpkgs direnv module automatically sources nix-direnv so no need to add it to the users direnvrc
and the persistDerivations option was removed as it's no longer needed
:)