### PR TITLE
Fix Nix file order docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,8 +303,8 @@ when deciding to update its cache.
     * `.envrc`,
     * A single nix file. In order of preference:
         + The file argument to `use nix`
-        + `default.nix` if it exists
         + `shell.nix` if it exists
+        + `default.nix` if it exists
 
 - for `use flake` this is:
     * `~/.direnvrc`


### PR DESCRIPTION
shell.nix file is used first if it exists, see https://github.com/nix-community/nix-direnv/blob/9178f71653285fff85b6a8712821b95273f95582/direnvrc#L340-L344