### PR TITLE
use_nix: watch for both shell.nix and default.nix

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -388,10 +388,7 @@ use_nix() {
     esac
   done
 
-  nix_direnv_watch_file "$HOME/.direnvrc" "$HOME/.config/direnv/direnvrc" ".envrc"
-  if [ -f "$nixfile" ]; then
-    nix_direnv_watch_file "$nixfile"
-  fi
+  nix_direnv_watch_file "$HOME/.direnvrc" "$HOME/.config/direnv/direnvrc" ".envrc" "shell.nix" "default.nix"
 
   local need_update=0
   local file=


### PR DESCRIPTION
In many cases they will shell.nix will depend on default.nix and when a user switches from default.nix to shell.nix we also want to invalidate the cache.

fixes https://github.com/nix-community/nix-direnv/issues/409