### PR TITLE
_nix_direnv_watches: update path regex to match capitalized path

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -208,7 +208,7 @@ _nix_direnv_watches() {
     return
   fi
   while IFS= read -r line; do
-    local regex='"path": "(.+)"$'
+    local regex='"[Pp]ath": "(.+)"$'
     if [[ "$line" =~ $regex ]]; then
       local path="${BASH_REMATCH[1]}"
       if [[ "$path" == "${XDG_DATA_HOME:-${HOME:-/var/empty}/.local/share}/direnv/allow/"* ]]; then


### PR DESCRIPTION
Small problem with a20b32d. In my environment (direnv 2.32.2) the keys in `DIRENV_WATCHES` are capitalized.