### PR TITLE
Release 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Put the following lines in your `.envrc`:
 
 ```bash
 if ! has nix_direnv_version || ! nix_direnv_version 3.0.0; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.0/direnvrc" "sha256-5XwUul/GUzj52MC5LvjHaZXDW2iLnl93tEQSYm9f3Rc="
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.0/direnvrc" "sha256-KE7jr1LFTRhYsLGRbQlVNYDjYsDTM7nOvDqU5Yp0Saw="
 fi
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ manage your shell with `programs.<your_shell>.enable = true`.
 Put the following lines in your `.envrc`:
 
 ```bash
-if ! has nix_direnv_version || ! nix_direnv_version 2.5.0; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.5.0/direnvrc" "sha256-5XwUul/GUzj52MC5LvjHaZXDW2iLnl93tEQSYm9f3Rc="
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.0/direnvrc" "sha256-5XwUul/GUzj52MC5LvjHaZXDW2iLnl93tEQSYm9f3Rc="
 fi
 ```
 

--- a/direnvrc
+++ b/direnvrc
@@ -76,7 +76,7 @@ EOF
 #
 # Checks that the nix-direnv version is at least as old as <version_at_least>.
 nix_direnv_version() {
-  declare major='2' minor='5' patch='0' # UPDATE(nix-direnv version)
+  declare major='3' minor='0' patch='0' # UPDATE(nix-direnv version)
 
   [[ $1 =~ ^([^+-.]*)(\.?)([^+-.]*)(\.?)([^+-]*)(-?)([^+]*)(\+?)(.*)$ ]]
   declare -a ver; ver=("${BASH_REMATCH[@]:1}")

--- a/templates/flake/.envrc
+++ b/templates/flake/.envrc
@@ -1,4 +1,4 @@
-if ! has nix_direnv_version || ! nix_direnv_version 2.5.0; then
-    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.5.0/direnvrc" "sha256-5XwUul/GUzj52MC5LvjHaZXDW2iLnl93tEQSYm9f3Rc="
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.0; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.0/direnvrc" "sha256-5XwUul/GUzj52MC5LvjHaZXDW2iLnl93tEQSYm9f3Rc="
 fi
 use flake

--- a/templates/flake/.envrc
+++ b/templates/flake/.envrc
@@ -1,4 +1,4 @@
 if ! has nix_direnv_version || ! nix_direnv_version 3.0.0; then
-    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.0/direnvrc" "sha256-5XwUul/GUzj52MC5LvjHaZXDW2iLnl93tEQSYm9f3Rc="
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.0/direnvrc" "sha256-KE7jr1LFTRhYsLGRbQlVNYDjYsDTM7nOvDqU5Yp0Saw="
 fi
 use flake


### PR DESCRIPTION
We just released 2.5.0 yesterday, but it strikes me that removing API surface is actually a major version bump. I'm opening a PR to handle the release to discuss a major release (wouldn't have bothered for a minor or point release)

Yes, we have back compat but we should still bump the major and keep the back compat until next major release.

Note that I didn't use the existing scripts, so a tag will need to be created after merge (or some other inclusion). 
The sha256 for fetchurl should be correct, however.