### PR TITLE
flake: remove garnix nixConfig

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,9 +6,6 @@
   inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
   inputs.treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
 
-  nixConfig.extra-substituters = [ "https://cache.garnix.io" ];
-  nixConfig.extra-trusted-public-keys = [ "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=" ];
-
   outputs = inputs @ { flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; }
       ({ lib, ... }: {


### PR DESCRIPTION
Not needed since this repo switched to buildbot in https://github.com/nix-community/nix-direnv/pull/424.