### PR TITLE
fix template after treefmt

### DIFF
--- a/templates/flake/flake.nix
+++ b/templates/flake/flake.nix
@@ -3,7 +3,7 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { nixpkgs, flake-utils }:
+  outputs = { nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};


### PR DESCRIPTION
fixes https://github.com/nix-community/nix-direnv/issues/431

It's probably for the best if it's also deadnix-safe for other users