### PR TITLE
make self-contained

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,17 +1,47 @@
-{ stdenv, nix, lib }:
+{ resholve, lib, coreutils, direnv, nix }:
 
-stdenv.mkDerivation {
-  name = "nix-direnv";
+# resholve does not yet support `finalAttrs` call pattern hence `rec`
+# https://github.com/abathur/resholve/issues/107
+resholve.mkDerivation rec {
+  pname = "nix-direnv";
+  version = "3.0.0";
 
-  src = ./.;
-
-  postPatch = ''
-    sed -i "2iNIX_BIN_PREFIX=${nix}/bin" direnvrc
-  '';
+  src = builtins.path {
+    path = ./.;
+    name = pname;
+  };
 
   installPhase = ''
-    install -m400 -D direnvrc $out/share/nix-direnv/direnvrc
+    install -m400 -D direnvrc $out/share/${pname}/direnvrc
   '';
+
+  solutions = {
+    default = {
+      scripts = [ "share/${pname}/direnvrc" ];
+      interpreter = "none";
+      inputs = [ coreutils direnv nix ];
+      fake = {
+        builtin = [
+          "PATH_add"
+          "direnv_layout_dir"
+          "has"
+          "log_error"
+          "log_status"
+          "watch_file"
+        ];
+        function = [
+          # not really a function - this is in an else branch for macOS/homebrew that
+          # cannot be reached when built with nix
+          "shasum"
+        ];
+      };
+      keep."$cmd" = true;
+      execer = [
+        "cannot:${direnv}/bin/direnv"
+        "cannot:${nix}/bin/nix"
+      ];
+    };
+  };
 
   meta = with lib; {
     description = "A fast, persistent use_nix implementation for direnv";

--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,11 @@ resholve.mkDerivation rec {
     name = pname;
   };
 
+  # drop min version checks which are redundant when built with nix
+  postPatch = ''
+    sed -i "/_require_version bash/,+2d" direnvrc
+  '';
+
   installPhase = ''
     install -m400 -D direnvrc $out/share/${pname}/direnvrc
   '';

--- a/direnvrc
+++ b/direnvrc
@@ -59,10 +59,6 @@ _nix_direnv_preflight() {
     _nix_direnv_fatal '$direnv environment variable was not defined. Was this script run inside direnv?'
   fi
 
-  if [[ -n ${NIX_BIN_PREFIX:-} ]]; then
-    PATH_add "$NIX_BIN_PREFIX"
-  fi
-
   # check command min versions, bash check uses $BASH_VERSION with _require_version
   # instead of _require_cmd_version because _require_cmd_version uses =~ operator which
   # would be a syntax error on bash < 3

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -16,6 +16,7 @@ if [[ "$(git symbolic-ref --short HEAD)" != "master" ]]; then
   exit 1
 fi
 
+sed -Ei "s!(version = ).*!\1\"$version\";!" default.nix
 sed -Ei "s!(NIX_DIRENV_VERSION=).*!\1$version!" direnvrc
 
 sed -i README.md templates/flake/.envrc \


### PR DESCRIPTION
This prepends `coreutils` and `direnv` to `$PATH` in addition to `nix` in order to make this self-contained.

Fixes #440.