### PR TITLE
envrc: watch direnvrc and *.nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
 strict_env
 source ./direnvrc
-watch_file shell.nix
+watch_file direnvrc *.nix
 use flake


### PR DESCRIPTION
I believe this way catches all dependencies of the shell environment.