### PR TITLE
Fix local flakes when prefixed with "path:" (again)

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -247,8 +247,8 @@ use_flake() {
   fi
 
   flake_expr="${1:-.}"
-  flake_dir="${flake_expr%#*}"
-  flake_dir=${flake_dir#"path:"}
+  flake_uri="${flake_expr%#*}"
+  flake_dir=${flake_uri#"path:"}
 
   if [[ $flake_expr == -* ]]; then
     local message="the first argument must be a flake expression"
@@ -310,7 +310,7 @@ use_flake() {
         mkdir -p "$flake_inputs"
         flake_input_paths=$(_nix flake archive \
           --json --no-write-lock-file \
-          "$flake_dir")
+          -- "$flake_uri")
 
         while [[ $flake_input_paths =~ /nix/store/[^\"]+ ]]; do
           local store_path="${BASH_REMATCH[0]}"


### PR DESCRIPTION
This change fixes regression introduced in commit 4bf5d40290981c867d70f6d3c0d505dd03bc2c0d. In particular, we should not be passing flake URI without schema to the nix flake archive command.

This fixes `use flake path:devel#direnv` in `.envrc` that previously errored at `nix flake archive […] "direnv"` step (that should have been `path:devel`).