### PR TITLE
[README] Show the `hide_env_diff` configuration in `home-manager` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ In `$HOME/.config/nixpkgs/home.nix` add
       enable = true;
       enableBashIntegration = true; # see note on other shells below
       nix-direnv.enable = true;
+      config = {
+        global = {
+          # Hides the rather large block of text that is usually printed when entering the environment.
+          hide_env_diff = true; 
+        };
+      };
     };
 
     bash.enable = true; # see note on other shells below


### PR DESCRIPTION
### Background:
After spending too much time trying to figure out how to silence the large block of text showing the exported variables upon entering the directory I came across an elegant solution described in this thread comment:
https://github.com/direnv/direnv/issues/68#issuecomment-2054033048 

### Quote:
Since direnv 2.34.0, to remove the "export" message completely, add hide_env_diff = true to ~/.config/direnv/direnv.toml in the global section:

```toml
[global]
# https://direnv.net/man/direnv.toml.1.html
hide_env_diff = true
```

### Changes:
Adds the required configuration to `home-manager` section in the `README`.

### Impact:
Will help out everyone (who views the `home-manager` section) to quickly find the required configuration setting.
This will greatly increase user retention as without this, the block of logs produced is a major turnoff IMO.

Thanks for this nice project.