### PR TITLE
Use ambient Nix when available, with a two stage fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,14 @@ invocation or are purely incidental and should not be relied upon.
   flake's devShell are invalid and nix-direnv has loaded the last known working
   shell.
 
+nix-direnv also respects the following environment variables for configuration.
+
+- `NIX_DIRENV_FALLBACK_NIX`: Can be set to a fallback Nix binary location, to be
+  used when a compatible one isn't available in `PATH`. Defaults to
+  `config.nix.package` if installed via the NixOS module, otherwise needs to be
+  set manually. Leave unset or empty to fail immediately when a Nix
+  implementation can't be found on `PATH`.
+
 ## General direnv tips
 
 - [Changing where direnv stores its cache][cache_location]

--- a/direnvrc
+++ b/direnvrc
@@ -29,8 +29,10 @@ _nix_direnv_warning() {
 
 _nix_direnv_error() { log_error "${_NIX_DIRENV_LOG_PREFIX}$*"; }
 
+_nix_direnv_nix=""
+
 _nix() {
-  nix --extra-experimental-features "nix-command flakes" "$@"
+  ${_nix_direnv_nix} --extra-experimental-features "nix-command flakes" "$@"
 }
 
 _require_version() {
@@ -53,6 +55,34 @@ _require_cmd_version() {
   _require_version "$cmd" "${BASH_REMATCH[1]}" "$required"
 }
 
+_nix_direnv_resolve_nix() {
+  local ambient_nix
+
+  if ambient_nix=$(command -v nix); then
+    if _require_cmd_version "${ambient_nix}" "${NIX_MIN_VERSION}"; then
+      echo "${ambient_nix}"
+      return 0
+    else
+      _nix_direnv_warning "Nix version in PATH is too old, wanted ${NIX_MIN_VERSION}+, got $(${ambient_nix} --version), will attempt fallback"
+    fi
+  else
+    _nix_direnv_warning "Could not find Nix in PATH, will attempt fallback"
+  fi
+
+  if [ -n "${NIX_DIRENV_FALLBACK_NIX}" ]; then
+    if _require_cmd_version "${NIX_DIRENV_FALLBACK_NIX}" "${NIX_MIN_VERSION}"; then
+      echo "${NIX_DIRENV_FALLBACK_NIX}"
+      return 0
+    else
+      _nix_direnv_error "Fallback Nix version is too old, wanted ${NIX_MIN_VERSION}+, got $(${NIX_DIRENV_FALLBACK_NIX} --version)"
+      return 1
+    fi
+  else
+    _nix_direnv_error "Could not find fallback Nix binary, please add Nix to PATH or set NIX_DIRENV_FALLBACK_NIX"
+    return 1
+  fi
+}
+
 _nix_direnv_preflight() {
   if [[ -z $direnv ]]; then
     # shellcheck disable=2016
@@ -66,10 +96,14 @@ _nix_direnv_preflight() {
     # _require_cmd_version because _require_cmd_version uses =~ operator which would be
     # a syntax error on bash < 3
     if ! _require_version bash "$BASH_VERSION" "$BASH_MIN_VERSION" ||
-      ! _require_cmd_version "$direnv" "$DIRENV_MIN_VERSION" || # direnv stdlib defines $direnv
-      ! _require_cmd_version nix "$NIX_MIN_VERSION"; then
+      # direnv stdlib defines $direnv
+      ! _require_cmd_version "$direnv" "$DIRENV_MIN_VERSION"; then
       return 1
     fi
+  fi
+
+  if ! _nix_direnv_nix=$(_nix_direnv_resolve_nix); then
+    return 1
   fi
 
   local layout_dir


### PR DESCRIPTION
First, we try to use the ambient Nix version.
Then, we try to use $NIX_DIRENV_FALLBACK_NIX, which is set by default, but can also be overridden by the user.
Only then, if neither is available, we fail.

Fixes #451.