### PR TITLE
Respect existing _nix_direnv_manual_reload

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -263,7 +263,7 @@ _nix_direnv_watches() {
   done < <($direnv show_dump "${DIRENV_WATCHES}")
 }
 
-_nix_direnv_manual_reload=0
+: "${_nix_direnv_manual_reload:=0}"
 nix_direnv_manual_reload() {
   _nix_direnv_manual_reload=1
 }


### PR DESCRIPTION
It's only initialized to `0` if it's not already set.

This fixes a niche-ish direnv use-case: I have `nix_direnv_manual_reload` set globally (inside my `direnvrc` config file). It works, but if I have nested envfiles it will be disabled (unless specified again). This can also be triggered by having `nix_direnv_manual_reload` on the nested `.envrc` but not on the outer one.

#### MWE
```bash
cd "$(mktemp -d)"

echo $'
{
  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
  outputs =
    { nixpkgs, ... }:
    let
      forEachSystem =
        f: nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (system: f nixpkgs.legacyPackages.system);
    in
    {
      devShells = forEachSystem (pkgs: {
        default = pkgs.mkShell { };
      });
    };

}' >flake.nix
echo 'use flake' >.envrc

mkdir inner
echo $'
nix_direnv_manual_reload
source_up
' >./inner/.envrc
cd inner
direnv allow # manual reload not set


```