### PR TITLE
Added `nix-systems` input

### DIFF
--- a/templates/flake/flake.nix
+++ b/templates/flake/flake.nix
@@ -1,7 +1,11 @@
 {
   description = "A basic flake with a shell";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.systems.url = "github.com:nix-systems/default";
+  inputs.flake-utils = {
+    url = "github:numtide/flake-utils";
+    inputs.systems.follows = "systems";
+  };
 
   outputs =
     { nixpkgs, flake-utils, ... }:


### PR DESCRIPTION
## Added `nix-systems` input

flake-utils provides finer control over "default systems" using [nix-systems](https://github.com/nix-systems).  It seemed reasonable to expose its `systems` input also in nix-direnv template.

### Testing 

<details><summary>Click here for the log</summary>

```sh
❯ nix fmt
warning: Git tree '/Users/ic/dev/nix-direnv' is dirty
WARN format: no formatter for path: LICENSE
WARN format: no formatter for path: pyproject.toml
traversed 33 files
emitted 33 files for processing
formatted 28 files (1 changed) in 680ms

nix-direnv on  master
❯ nix flake check --all-systems

nix-direnv on  master took 29s
❯
```

</details>


