### PR TITLE
Fix syntax for nix-systems input

### DIFF
--- a/templates/flake/flake.nix
+++ b/templates/flake/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "A basic flake with a shell";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.systems.url = "github.com:nix-systems/default";
+  inputs.systems.url = "github:nix-systems/default";
   inputs.flake-utils = {
     url = "github:numtide/flake-utils";
     inputs.systems.follows = "systems";


### PR DESCRIPTION
Removed unsupported .com in nix-systems url input.