### PR TITLE
Always set nix-direnv-reload as executable

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -140,9 +140,7 @@ touch "$PWD/.envrc"
 touch -r "$PWD/.envrc" "${layout_dir}"/*.rc
 EOF
 
-  if [[ ! -x "${layout_dir}/bin/nix-direnv-reload" ]]; then
-    chmod +x "${layout_dir}/bin/nix-direnv-reload"
-  fi
+  chmod +x "${layout_dir}/bin/nix-direnv-reload"
 
   PATH_add "${layout_dir}/bin"
 }


### PR DESCRIPTION
I am not sure why, but on docker bind mounts using virtiofs and gcsFuse, `-x` is always true for a file which exists.  This means that, before this commit was merged, when using nix-direnv in manual mode on a devcontainer with docker desktop on mac, `nix-direnv-reload` would be created and then not set as executable, and if they tried to run it users would see an error like `bad interpreter: Permission denied`.  After this commit is merged, these scenarios work.

Here's some discussion: https://github.com/docker/for-mac/issues/5029 

Other tools have run into this: https://github.com/pre-commit/identify/pull/189