### PR TITLE
rely on function autocalling

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -492,11 +492,9 @@ use_nix() {
       if [[ -n $packages ]]; then
         extra_args+=("--expr" "with import <nixpkgs> {}; mkShell { buildInputs = [ $packages ]; }")
       else
-        # figure out what attribute we should build
-        if [[ -z $attribute ]]; then
-          extra_args+=("--file" "$nixfile")
-        else
-          extra_args+=("--expr" "(import ${nixfile} {}).${attribute}")
+        extra_args+=("--file" "$nixfile")
+        if [[ -n $attribute ]]; then
+          extra_args+=("$attribute")
         fi
       fi
 


### PR DESCRIPTION
Instead of the current behavior of always trying to call the expression as a function, or alternatively, trying to implement autocalling manually with `builtins.isFunction`.

Fixes #285.