### PR TITLE
Fix warnings not being printed

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -15,16 +15,18 @@ _nix_direnv_info() {
 }
 
 _nix_direnv_warning() {
-  if [[ -n $DIRENV_LOG_FORMAT ]]; then
-    local msg=$* color_normal='' color_warning=''
-    if [[ -t 2 ]]; then
-      color_normal="\e[m"
-      color_warning="\e[33m"
-    fi
-    # shellcheck disable=SC2059
-    printf "${color_warning}${DIRENV_LOG_FORMAT}${color_normal}\n" \
-      "${_NIX_DIRENV_LOG_PREFIX}${msg}" >&2
+  local msg=$*
+  local color_normal=""
+  local color_warning=""
+
+  if [[ -t 2 ]]; then
+    color_normal="\e[m"
+    color_warning="\e[33m"
   fi
+
+  printf "%b" "$color_warning"
+  log_status "${_NIX_DIRENV_LOG_PREFIX}${msg}"
+  printf "%b" "$color_normal"
 }
 
 _nix_direnv_error() { log_error "${_NIX_DIRENV_LOG_PREFIX}$*"; }


### PR DESCRIPTION
Since a few days ago (so I assume starting at [direnv 2.36.0](https://github.com/direnv/direnv/releases/tag/v2.36.0)), the `DIRENV_LOG_FORMAT` environment variable is not set by default. This breaks `nix-direnv` every time it's called with `strict_env` due to an unbound variable error.

Even if the variable was accessed safely, warnings won't be rendered anymore because it's empty and we skip printing anything when that happens.

With this approach, we use the stdlib `log_status`, and just wrap it around ANSI escapes for the yellow color.

This has the advantage of delegating the logging format logic back to `direnv`, but it might be possible that at some point in the future `direnv` sanitizes the strings and breaks this solution. However, the alternative is to keep relying on `DIRENV_LOG_FORMAT`, which will break by default, and in doing so we would also be ignoring the new `log_format` option in `direnv.toml`.

-----

Other thing I tried to get colored logs "idiomatically" was to embed them _inside_ the `log_status` arguments, not around it:
```bash
log_status "$(printf "%b" $color_warning)${_NIX_DIRENV_LOG_PREFIX}${msg}$(printf "%b" $color_normal)"
```
This makes the output look like this (note that the `direnv:` prefix is not colored):
![image](https://github.com/user-attachments/assets/bb9fce97-75af-493d-8275-52f0ac80cd5c)

But it would be a valid alternative if, for example, the behaviour at https://github.com/direnv/direnv/pull/884 is restored.
