### PR TITLE
Make the example usage commands less intrusive for non-nix users

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ pkgs.mkShell {
 Then add the line `use nix` to your envrc:
 
 ```console
-$ echo "use nix" >> .envrc
+$ echo "if has nix; then use nix; fi" >> .envrc
 $ direnv allow
 ```
 
@@ -199,7 +199,7 @@ $ nix flake new -t github:nix-community/nix-direnv <desired output path>
 ### Integrating with a existing flake
 
 ```console
-$ echo "use flake" >> .envrc && direnv allow
+$ echo "if has nix; then use flake; fi" >> .envrc && direnv allow
 ```
 
 The `use flake` line also takes an additional arbitrary flake parameter, so you


### PR DESCRIPTION
This is to humbly suggest making the usage examples less intrusive for non-Nix folks. I frequently use just plain `use flake` in my `.envrc` as I start private repository, because it works fine for _me_, but I usually forget to update it to something less intrusive when I share code with other people.

This leads to a bit of frustration as there are people out there that do use direnv, but don't use Nix. For them the configuration is annoyingly broken. Hitting this snag does not provide the best context to learn about Nix, so I would suggest to perhaps provide usage examples that fall back more gracefully.

This changes some of the examples to make the usage of direnv less intrusive for non-nix folks. I've kept the one-liner nature of these. It's not as nice code, but it's nicer behavior IMO.