### PR TITLE
Add details for `nix profile` installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ CPU load).
 
 ## Installation
 
-> **Heads up**: nix-direnv requires a modern Bash. MacOS ships with bash 3.2
-> from 2007. As a work-around we suggest that macOS users install `direnv` via
-> Nix or Homebrew. There are different ways to install nix-direnv, pick your
-> favourite:
+> [!WARNING]\
+> We assume that [direnv](https://direnv.net/) is installed properly because
+> nix-direnv IS NOT a replacement for regular direnv _(only some of its
+> functionality)_.
+
+> [!NOTE]\
+> nix-direnv requires a modern Bash. MacOS ships with bash 3.2 from 2007. As a
+> work-around we suggest that macOS users install `direnv` via Nix or Homebrew.
+> There are different ways to install nix-direnv, pick your favourite:
 
 <details>
   <summary> Via home-manager (Recommended)</summary>


### PR DESCRIPTION
Previous version of these instructions did not make it very clear that you need to have nix-direnv _together_ with regular direnv.

As a newcomer, I had to learn this the hard way and spend some time debugging this. I'm sure this will be very helpful to other people like me.

Even better, why not even specify direnv as a `buildInput` for `nix-direnv` in `flake.nix`? 