### PR TITLE
drop binary cache from flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,6 @@
 {
   description = "A faster, persistent implementation of `direnv`'s `use_nix`, to replace the built-in one.";
 
-  nixConfig.extra-substituters = [ "https://cache.thalheim.io" ];
-  nixConfig.extra-trusted-public-keys = [
-    "cache.thalheim.io-1:R7msbosLEZKrxk/lKxf9BTjOOH7Ax3H0Qj0/6wiHOgc="
-  ];
-
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts = {


### PR DESCRIPTION

It's not really needed anymore and concerns user when instantiating
templates: https://github.com/nix-community/nix-direnv/issues/576