### PR TITLE
resolve symbolic links to nixpkgs

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -361,7 +361,7 @@ use_nix() {
 
   local layout_dir path version
   layout_dir=$(direnv_layout_dir)
-  if path=$(_nix eval --impure --expr "<nixpkgs>" 2>/dev/null); then
+  if path=$(realpath -e "$(_nix eval --impure --expr "<nixpkgs>" 2>/dev/null)"); then
     if [[ -f "${path}/.version-suffix" ]]; then
       version=$(<"${path}/.version-suffix")
     elif [[ -f "${path}/.git/HEAD" ]]; then


### PR DESCRIPTION
This fixes version detection if nixpkgs is a symbolic link into the nix store:

```
$ head -3 shell.nix
{
  pkgs ? import <nixpkgs> { },
}:

$ nix eval --impure --expr '<nixpkgs>'
/etc/nix/path/nixpkgs

$ nix eval --impure --expr '<nixpkgs>' | xargs realpath
/nix/store/mcvd7n2ii0nbhpcl56mbb7nhy3005zhv-source

$ ll .direnv # before
total 76K
drwxr-xr-x 1 r r  34 2023.10.13 17:02 bin/
lrwxrwxrwx 1 r r  57 2025.06.14 20:57 nix-profile-unknown -> /nix/store/32xvp8j127n0n4px6hiwpz98zpaz1gx3-nix-shell-env
-rw-r--r-- 1 r r 71K 2025.06.14 20:57 nix-profile-unknown.rc

$ ll .direnv # after
total 76K
drwxr-xr-x 1 r r  34 2023.10.13 17:02 bin/
lrwxrwxrwx 1 r r  57 2025.06.14 20:59 nix-profile-25.11-mcvd7n2ii0nbhpcl -> /nix/store/32xvp8j127n0n4px6hiwpz98zpaz1gx3-nix-shell-env
-rw-r--r-- 1 r r 71K 2025.06.14 20:59 nix-profile-25.11-mcvd7n2ii0nbhpcl.rc
```