### PR TITLE
Add GC root refresh functionality

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -189,6 +189,15 @@ _nix_add_gcroot() {
   _nix build --out-link "$symlink" "$storepath"
 }
 
+_nix_refresh_gcroots() {
+  # Use touch to update all symlinks' timestamps to prevent nh
+  # from garbage collecting the frequently used direnv environment.
+  local layout_dir
+  layout_dir=$(direnv_layout_dir)
+
+  touch -h "${layout_dir}"/flake-profile-* "${layout_dir}"/flake-inputs/* "${layout_dir}"/nix-profile-*
+}
+
 _nix_clean_old_gcroots() {
   local layout_dir=$1
 
@@ -354,6 +363,7 @@ use_flake() {
     if [[ -e ${profile_rc} ]]; then
       # Our cache is valid, use that
       _nix_direnv_info "Using cached dev shell"
+      _nix_refresh_gcroots
     else
       # We don't have a profile_rc to use!
       _nix_direnv_error "use_flake failed - Is your flake's devShell working?"
@@ -515,6 +525,7 @@ use_nix() {
   else
     if [[ -e ${profile_rc} ]]; then
       _nix_direnv_info "Using cached dev shell"
+      _nix_refresh_gcroots
     else
       _nix_direnv_error "use_nix failed - Is your nix shell working?"
       unset IN_NIX_SHELL


### PR DESCRIPTION
Hi! I use the [nh](https://github.com/nix-community/nh) tool to garbage-collect unused Nix environments — by default, it removes environments that haven’t been used recently. However, I noticed it sometimes cleans up environments that are still actively used but whose symlink files haven’t been updated recently.

After some digging, I found that **nh** determines whether an environment is “in use” based on the symlink file’s modification time (mtime). This means that even if an environment is used daily via **direnv**, **nh** may incorrectly mark it for garbage collection if the timestamp is old.

This PR introduces **GC root refresh functionality** to address that issue.

### Changes
- Add `_nix_refresh_gcroots` function to update symlink mtimes  
- Prevent **nh** from collecting frequently used **direnv** environments  
- Refresh GC roots when using cached flakes and Nix dev shells