### PR TITLE
fix: chmod permission error when nix-direnv-reload owned by different user

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -96,7 +96,10 @@ _nix_direnv_preflight() {
   # Because direnv_layout_dir is user controlled,
   # we can't assume to be able to reverse it to get the source dir
   # So there's little to be done about this.
-  cat >"${layout_dir}/bin/nix-direnv-reload" <<-EOF
+  # Use install -m instead of cat + chmod to atomically create the file with
+  # correct permissions. This works even when an existing file is owned by
+  # another user, as install unlinks and recreates the file.
+  install -m 755 /dev/stdin "${layout_dir}/bin/nix-direnv-reload" <<-EOF
 #!/usr/bin/env bash
 set -e
 if [[ ! -d "$PWD" ]]; then
@@ -117,8 +120,6 @@ touch "$PWD/.envrc"
 # This makes sure that we know we are up to date.
 touch -r "$PWD/.envrc" "${layout_dir}"/*.rc
 EOF
-
-  chmod +x "${layout_dir}/bin/nix-direnv-reload"
 
   PATH_add "${layout_dir}/bin"
 }


### PR DESCRIPTION
## Summary

Fix `chmod: Operation not permitted` error when `nix-direnv-reload` file is owned by a
different user (e.g., a colleague entered direnv first).
```console
$ direnv allow
direnv: loading /etc/nixos/.envrc
direnv: using flake . --impure --accept-flake-config
chmod: changing permissions of '/etc/nixos/.direnv/bin/nix-direnv-reload': Operation not permitted
```

## Problem

`chmod` cannot change permissions on a file owned by another user.

## Solution

Use `install -m 755 /dev/stdin` instead of separate `cat` + `chmod`. The `install` command
unlinks and recreates the file rather than modifying it in place, which works even when the
existing file is owned by another user.


### Test
Add this to `.envrc`:
```bash
source_url "https://raw.githubusercontent.com/tennox/nix-direnv/fix/chmod-permission-error/direnvrc" \
    "sha256-rXKNtMDtfdKIeU3FnIDmEAyF5NZ3of+Yz2YuU8pYeJI="
```