### PR TITLE
Set `inNixShell`

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -525,7 +525,7 @@ use_nix() {
       if [[ -n $packages ]]; then
         extra_args+=("--expr" "with import <nixpkgs> {}; mkShell { buildInputs = [ $packages ]; }")
       else
-        extra_args+=("--file" "$nixfile")
+        extra_args+=("--file" "$nixfile" --arg inNixShell true)
         if [[ -n $attribute ]]; then
           extra_args+=("$attribute")
         fi


### PR DESCRIPTION
`nix-shell` [passes a `inNixShell = true` argument](https://github.com/NixOS/nix/pull/3168) when evaluating a file, so we should replicate this behaviour. There is another mechanism for signaling that we are in a nix shell, namely the `IN_NIX_SHELL` environment variable (which both nix-shell and nix-direnv also set), but this is by nature [not a good solution](https://github.com/NixOS/nixpkgs/issues/436814) since it leaks into e.g. further `nix-build` invocations in nix shells.

This only concerns non-flake setups, of course.

ping @roberth @sternenseemann