### PR TITLE
Fix "install: skipping file '/dev/stdin', as it was replaced while being copied" on MacOS

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -96,10 +96,9 @@ _nix_direnv_preflight() {
   # Because direnv_layout_dir is user controlled,
   # we can't assume to be able to reverse it to get the source dir
   # So there's little to be done about this.
-  # Use install -m instead of cat + chmod to atomically create the file with
-  # correct permissions. This works even when an existing file is owned by
-  # another user, as install unlinks and recreates the file.
-  install -m 755 /dev/stdin "${layout_dir}/bin/nix-direnv-reload" <<-EOF
+  # Remove first to handle case where file is owned by a different user
+  rm -f "${layout_dir}/bin/nix-direnv-reload"
+  cat >"${layout_dir}/bin/nix-direnv-reload" <<-EOF
 #!/usr/bin/env bash
 set -e
 if [[ ! -d "$PWD" ]]; then
@@ -120,6 +119,7 @@ touch "$PWD/.envrc"
 # This makes sure that we know we are up to date.
 touch -r "$PWD/.envrc" "${layout_dir}"/*.rc
 EOF
+  chmod +x "${layout_dir}/bin/nix-direnv-reload"
 
   PATH_add "${layout_dir}/bin"
 }


### PR DESCRIPTION
- MacOS 15.7.3 (24G419)
- zsh 5.9,
- nix (Determinate Nix 3.15.2) 2.33.1
- direnv 2.37.1

Running:

```sh
direnv allow
```

```sh
direnv: loading ~/dev/foo/.envrc
direnv: using nix
install: skipping file '/dev/stdin', as it was replaced while being copied
direnv: nix-direnv: Using cached dev shell
```

Seems to be from commit: https://github.com/nix-community/nix-direnv/commit/01fdb24f5dac7ea63b3cfebbf4622a2f904fee15

Instead of using `install`, we use `rm -f` + `cat` + `chmod`, no longer a single command, but it works..

> The rm -f handles the original issue (chmod failing when file is owned by another user) by removing the old file first so cat creates a new one owned by the current user.

Essentially , before:

```sh
# Use install -m instead of cat + chmod to atomically create the file with
# correct permissions. This works even when an existing file is owned by
# another user, as install unlinks and recreates the file.
install -m 755 /dev/stdin "${layout_dir}/bin/nix-direnv-reload" <<-EOF
```

After:

```sh
# Remove first to handle case where file is owned by a different user
rm -f "${layout_dir}/bin/nix-direnv-reload"
cat >"${layout_dir}/bin/nix-direnv-reload" <<-EOF
```

And after the heredoc closing EOF, `chmod +x "${layout_dir}/bin/nix-direnv-reload"`.

---

Could be related to https://github.com/NixOS/nix/issues/9330 ?

---

This now works as expected for me, but the weird part is that it seems to be fine on Linux, from my testing. I'm going to guess MacOS might still have the file open or something, especially if you use something like Kandji (enterprise MDM file scanning policy thing), but could also be an issue with antivirus if users use something like that (I don't, just another theory)?

---

Feel free to do whatever with this PR, change it, close it, go a different direction -- this fixed it for me.
