### PR TITLE
Print at most 5 newer watched files

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -326,12 +326,12 @@ use_flake() {
     fi
   done
 
-if [[ ${#newer_files[@]} -gt 0 ]]; then
+  if [[ ${#newer_files[@]} -gt 0 ]]; then
     _nix_direnv_info "cache invalidated: ${#newer_files[@]} files newer than cache:"
     echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
     printf "%s\n" "${newer_files[@]:0:5}" >/dev/stderr
-    [[ ${#newer_files[@]} -gt 5 ]] && echo "And $((${#newer_files[@]} - 5)) more" > /dev/stderr
-fi
+    [[ ${#newer_files[@]} -gt 5 ]] && echo "And $((${#newer_files[@]} - 5)) more" >/dev/stderr
+  fi
 
   if [[ $profile_missing -eq 1 || $profile_rc_missing -eq 1 || ${#newer_files[@]} -gt 0 ]]; then
     if [[ $_nix_direnv_manual_reload -eq 1 && -z ${_nix_direnv_force_reload-} ]]; then
@@ -515,12 +515,12 @@ use_nix() {
     fi
   done
 
-if [[ ${#newer_files[@]} -gt 0 ]]; then
+  if [[ ${#newer_files[@]} -gt 0 ]]; then
     _nix_direnv_info "cache invalidated: ${#newer_files[@]} files newer than cache:"
     echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
     printf "%s\n" "${newer_files[@]:0:5}" >/dev/stderr
-    [[ ${#newer_files[@]} -gt 5 ]] && echo "And $((${#newer_files[@]} - 5)) more" > /dev/stderr
-fi
+    [[ ${#newer_files[@]} -gt 5 ]] && echo "And $((${#newer_files[@]} - 5)) more" >/dev/stderr
+  fi
 
   if [[ $profile_missing -eq 1 || $profile_rc_missing -eq 1 || ${#newer_files[@]} -gt 0 ]]; then
     if [[ $_nix_direnv_manual_reload -eq 1 && -z ${_nix_direnv_force_reload-} ]]; then

--- a/direnvrc
+++ b/direnvrc
@@ -318,27 +318,22 @@ use_flake() {
     profile_rc_missing=1
   fi
 
-  local files_nt_profilerc=0
   local file=
   local newer_files
   for file in "${watches[@]}"; do
     if [[ $file -nt $profile_rc ]]; then
       newer_files+=("$file")
-      files_nt_profilerc=$((files_nt_profilerc + 1))
     fi
   done
 
-  if [[ $files_nt_profilerc -gt 5 ]]; then
-    _nix_direnv_info "cache invalidated: $files_nt_profilerc files newer than cache, including:"
+if [[ ${#newer_files[@]} -gt 0 ]]; then
+    _nix_direnv_info "cache invalidated: ${#newer_files[@]} files newer than cache:"
     echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
     printf "%s\n" "${newer_files[@]:0:5}" >/dev/stderr
-  elif [[ $files_nt_profilerc -gt 0 ]]; then
-    _nix_direnv_info "cache invalidated: files newer than cache:"
-    echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
-    printf "%s\n" "${newer_files[@]}" >/dev/stderr
-  fi
+    [[ ${#newer_files[@]} -gt 5 ]] && echo "And $((${#newer_files[@]} - 5)) more" > /dev/stderr
+fi
 
-  if [[ $profile_missing -eq 1 || $profile_rc_missing -eq 1 || $files_nt_profilerc -gt 0 ]]; then
+  if [[ $profile_missing -eq 1 || $profile_rc_missing -eq 1 || ${#newer_files[@]} -gt 0 ]]; then
     if [[ $_nix_direnv_manual_reload -eq 1 && -z ${_nix_direnv_force_reload-} ]]; then
       _nix_direnv_warn_manual_reload "$profile_rc"
 
@@ -512,27 +507,22 @@ use_nix() {
     profile_rc_missing=1
   fi
 
-  local files_nt_profilerc=0
   local file=
   local newer_files
   for file in "${watches[@]}"; do
     if [[ $file -nt $profile_rc ]]; then
       newer_files+=("$file")
-      files_nt_profilerc=$((files_nt_profilerc + 1))
     fi
   done
 
-  if [[ $files_nt_profilerc -gt 5 ]]; then
-    _nix_direnv_info "cache invalidated: $files_nt_profilerc files newer than cache, including:"
+if [[ ${#newer_files[@]} -gt 0 ]]; then
+    _nix_direnv_info "cache invalidated: ${#newer_files[@]} files newer than cache:"
     echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
     printf "%s\n" "${newer_files[@]:0:5}" >/dev/stderr
-  elif [[ $files_nt_profilerc -gt 0 ]]; then
-    _nix_direnv_info "cache invalidated: files newer than cache:"
-    echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
-    printf "%s\n" "${newer_files[@]}" >/dev/stderr
-  fi
+    [[ ${#newer_files[@]} -gt 5 ]] && echo "And $((${#newer_files[@]} - 5)) more" > /dev/stderr
+fi
 
-  if [[ $profile_missing -eq 1 || $profile_rc_missing -eq 1 || $files_nt_profilerc -gt 0 ]]; then
+  if [[ $profile_missing -eq 1 || $profile_rc_missing -eq 1 || ${#newer_files[@]} -gt 0 ]]; then
     if [[ $_nix_direnv_manual_reload -eq 1 && -z ${_nix_direnv_force_reload-} ]]; then
       _nix_direnv_warn_manual_reload "$profile_rc"
     else

--- a/direnvrc
+++ b/direnvrc
@@ -319,7 +319,7 @@ use_flake() {
   fi
 
   local file=
-  local newer_files
+  local newer_files=()
   for file in "${watches[@]}"; do
     if [[ $file -nt $profile_rc ]]; then
       newer_files+=("$file")
@@ -508,7 +508,7 @@ use_nix() {
   fi
 
   local file=
-  local newer_files
+  local newer_files=()
   for file in "${watches[@]}"; do
     if [[ $file -nt $profile_rc ]]; then
       newer_files+=("$file")

--- a/direnvrc
+++ b/direnvrc
@@ -327,7 +327,7 @@ use_flake() {
   done
 
   if [[ ${#newer_files[@]} -gt 0 ]]; then
-    _nix_direnv_info "cache invalidated: ${#newer_files[@]} files newer than cache:"
+    _nix_direnv_info "cache invalidated: files newer than cache:"
     echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
     printf "%s\n" "${newer_files[@]:0:5}" >/dev/stderr
     [[ ${#newer_files[@]} -gt 5 ]] && echo "And $((${#newer_files[@]} - 5)) more" >/dev/stderr
@@ -516,7 +516,7 @@ use_nix() {
   done
 
   if [[ ${#newer_files[@]} -gt 0 ]]; then
-    _nix_direnv_info "cache invalidated: ${#newer_files[@]} files newer than cache:"
+    _nix_direnv_info "cache invalidated: files newer than cache:"
     echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
     printf "%s\n" "${newer_files[@]:0:5}" >/dev/stderr
     [[ ${#newer_files[@]} -gt 5 ]] && echo "And $((${#newer_files[@]} - 5)) more" >/dev/stderr

--- a/direnvrc
+++ b/direnvrc
@@ -318,23 +318,27 @@ use_flake() {
     profile_rc_missing=1
   fi
 
-  local file_nt_profilerc=0
+  local files_nt_profilerc=0
   local file=
   local newer_files
   for file in "${watches[@]}"; do
     if [[ $file -nt $profile_rc ]]; then
       newer_files+=("$file")
-      file_nt_profilerc=1
+      files_nt_profilerc=$((files_nt_profilerc + 1))
     fi
   done
 
-  if [[ $file_nt_profilerc -eq 1 ]]; then
+  if [[ $files_nt_profilerc -gt 5 ]]; then
+    _nix_direnv_info "cache invalidated: $files_nt_profilerc files newer than cache, including:"
+    echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
+    printf "%s\n" "${newer_files[@]:0:5}" >/dev/stderr
+  elif [[ $files_nt_profilerc -gt 0 ]]; then
     _nix_direnv_info "cache invalidated: files newer than cache:"
     echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
     printf "%s\n" "${newer_files[@]}" >/dev/stderr
   fi
 
-  if [[ $profile_missing -eq 1 || $profile_rc_missing -eq 1 || $file_nt_profilerc -eq 1 ]]; then
+  if [[ $profile_missing -eq 1 || $profile_rc_missing -eq 1 || $files_nt_profilerc -gt 0 ]]; then
     if [[ $_nix_direnv_manual_reload -eq 1 && -z ${_nix_direnv_force_reload-} ]]; then
       _nix_direnv_warn_manual_reload "$profile_rc"
 
@@ -508,23 +512,27 @@ use_nix() {
     profile_rc_missing=1
   fi
 
-  local file_nt_profilerc=0
+  local files_nt_profilerc=0
   local file=
   local newer_files
   for file in "${watches[@]}"; do
     if [[ $file -nt $profile_rc ]]; then
       newer_files+=("$file")
-      file_nt_profilerc=1
+      files_nt_profilerc=$((files_nt_profilerc + 1))
     fi
   done
 
-  if [[ $file_nt_profilerc -eq 1 ]]; then
+  if [[ $files_nt_profilerc -gt 5 ]]; then
+    _nix_direnv_info "cache invalidated: $files_nt_profilerc files newer than cache, including:"
+    echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
+    printf "%s\n" "${newer_files[@]:0:5}" >/dev/stderr
+  elif [[ $files_nt_profilerc -gt 0 ]]; then
     _nix_direnv_info "cache invalidated: files newer than cache:"
     echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
     printf "%s\n" "${newer_files[@]}" >/dev/stderr
   fi
 
-  if [[ $profile_missing -eq 1 || $profile_rc_missing -eq 1 || $file_nt_profilerc -eq 1 ]]; then
+  if [[ $profile_missing -eq 1 || $profile_rc_missing -eq 1 || $files_nt_profilerc -gt 0 ]]; then
     if [[ $_nix_direnv_manual_reload -eq 1 && -z ${_nix_direnv_force_reload-} ]]; then
       _nix_direnv_warn_manual_reload "$profile_rc"
     else


### PR DESCRIPTION
Fixes #733. Example output from testing this locally with `use nix`:

```
> touch flake.nix
direnv: loading ~/Code/mwb/.envrc
direnv: using nix ./shell.nix -A default
direnv: nix-direnv: cache invalidated: profile (/Users/harry/Code/mwb/.direnv/nix-profile-26.05-klzydr6a4fwr1vbg-80675a43cf44443a60e0262cf0ff88cca193456c) does not exist
direnv: nix-direnv: cache invalidated: profile_rc (/Users/harry/Code/mwb/.direnv/nix-profile-26.05-klzydr6a4fwr1vbg-80675a43cf44443a60e0262cf0ff88cca193456c.rc) does not exist
direnv: nix-direnv: cache invalidated: 989 files newer than cache, including:
nix-direnv: /Users/harry/Code/mwb/.envrc
/Users/harry/Code/mwb/nix/deps-manual/persistent-typed-db.nix
/Users/harry/Code/mwb/nix/deps-manual/static-ls.nix
/Users/harry/Code/mwb/nix/deps-manual/buck-worker-proto.nix
/Users/harry/Code/mwb/nix/deps-manual/services.nix
direnv: nix-direnv: cache does not exist. use "nix-direnv-reload" to create it
```