### PR TITLE
Allow disabling logging of the reason for cache invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,9 @@ nix-direnv also respects the following environment variables for configuration.
   set manually. Leave unset or empty to fail immediately when a Nix
   implementation can't be found on `PATH`.
 
+- `NIX_DIRENV_LOG_REASON`: On reload, print the files that were changed, causing
+  the cache to be invalidated. Enabled by default - set to `1` to disable.
+
 ## General direnv tips
 
 - [Changing where direnv stores its cache][cache_location]

--- a/direnvrc
+++ b/direnvrc
@@ -32,6 +32,8 @@ _nix_direnv_error() { log_error "${_NIX_DIRENV_LOG_PREFIX}$*"; }
 
 _nix_direnv_nix=""
 
+_nix_direnv_log_reason=""
+
 _nix() {
   ${_nix_direnv_nix} --no-warn-dirty --extra-experimental-features "nix-command flakes" "$@"
 }
@@ -73,6 +75,10 @@ _nix_direnv_preflight() {
       ! _require_cmd_version "$direnv" "$DIRENV_MIN_VERSION"; then
       return 1
     fi
+  fi
+
+  if [[ -n ${NIX_DIRENV_LOG_REASON:-} ]]; then
+    _nix_direnv_log_reason="${NIX_DIRENV_LOG_REASON}"
   fi
 
   if command -v nix >/dev/null 2>&1; then
@@ -326,7 +332,7 @@ use_flake() {
     fi
   done
 
-  if [[ ${#newer_files[@]} -gt 0 ]]; then
+  if [[ ${#newer_files[@]} -gt 0 && $_nix_direnv_log_reason -ne 1 ]]; then
     _nix_direnv_info "cache invalidated: files newer than cache:"
     echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
     printf "%s\n" "${newer_files[@]:0:5}" >/dev/stderr
@@ -516,7 +522,7 @@ use_nix() {
     fi
   done
 
-  if [[ ${#newer_files[@]} -gt 0 ]]; then
+  if [[ ${#newer_files[@]} -gt 0 && $_nix_direnv_log_reason -ne 1 ]]; then
     _nix_direnv_info "cache invalidated: files newer than cache:"
     echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
     printf "%s\n" "${newer_files[@]:0:5}" >/dev/stderr


### PR DESCRIPTION
I'm using `nix-direnv-manual-reload`, but the logging messages still print, even when I haven't manually reloaded. I also personally find them a bit spammy. Now they can be disabled by setting `NIX_DIRENV_LOG_REASON=1`. I've tested this and can confirm it functions.