### PR TITLE
direnvrc: use >&2 instead of >/dev/stderr

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -320,9 +320,9 @@ use_flake() {
 
   if [[ ${#newer_files[@]} -gt 0 ]]; then
     _nix_direnv_info "cache invalidated: files newer than cache:"
-    echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
-    printf "%s\n" "${newer_files[@]:0:5}" >/dev/stderr
-    [[ ${#newer_files[@]} -gt 5 ]] && echo "And $((${#newer_files[@]} - 5)) more" >/dev/stderr
+    echo -n "$_NIX_DIRENV_LOG_PREFIX" >&2
+    printf "%s\n" "${newer_files[@]:0:5}" >&2
+    [[ ${#newer_files[@]} -gt 5 ]] && echo "And $((${#newer_files[@]} - 5)) more" >&2
   fi
 
   if [[ $profile_missing -eq 1 || $profile_rc_missing -eq 1 || ${#newer_files[@]} -gt 0 ]]; then
@@ -513,9 +513,9 @@ use_nix() {
 
   if [[ ${#newer_files[@]} -gt 0 ]]; then
     _nix_direnv_info "cache invalidated: files newer than cache:"
-    echo -n "$_NIX_DIRENV_LOG_PREFIX" >/dev/stderr
-    printf "%s\n" "${newer_files[@]:0:5}" >/dev/stderr
-    [[ ${#newer_files[@]} -gt 5 ]] && echo "And $((${#newer_files[@]} - 5)) more" >/dev/stderr
+    echo -n "$_NIX_DIRENV_LOG_PREFIX" >&2
+    printf "%s\n" "${newer_files[@]:0:5}" >&2
+    [[ ${#newer_files[@]} -gt 5 ]] && echo "And $((${#newer_files[@]} - 5)) more" >&2
   fi
 
   if [[ $profile_missing -eq 1 || $profile_rc_missing -eq 1 || ${#newer_files[@]} -gt 0 ]]; then


### PR DESCRIPTION
`>/dev/stderr` reopens `/proc/self/fd/2`. When fd 2 is a unix socket, `open()` fails with `ENXIO` ("No such device or address"). Node's `child_process.exec()` wires child stdio to `socketpair()`, so anything that drives direnv from node (editor/agent integrations) hits this on a cold cache, and under `strict_env` the whole `.envrc` aborts:

```
.../nix-direnv/direnvrc:336: /dev/stderr: No such device or address
direnv: error exit status 1
```

`>&2` dups the existing fd and works regardless of what stderr is connected to.

Regressed in #733.
