### PR TITLE
Don't refresh gcroots

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,23 @@ nix-direnv also respects the following environment variables for configuration.
   set manually. Leave unset or empty to fail immediately when a Nix
   implementation can't be found on `PATH`.
 
+#### Notes on nh integration
+
+`nh` is a modern nix helper utility that generally makes interacting with the
+nix tooling much better and more friendly. In the past, nix-direnv had some
+specific functionality to update gcroots whenever the environment was refreshed
+so that `nh` would consider those gcroots "fresh" and would not clean them up
+when `nh clean` was invoked.
+
+Modern versions of `nh` (4.4.0+) introduce a `--keep-one` argument to the
+`clean` subcommand, which specifically keeps one revision of every direnv's
+gcroots, which allows easily keeping the latest revision of every nix-direnv
+related gcroot so you're not redownloading the state unnecessarily.
+
+Because of this functionality (and because it interfered with other common
+usage), we have reverted our changes supporting this functionality. Please use
+`--keep-one` if you want a specific gcroot keps, regardless of age.
+
 ## General direnv tips
 
 - [Changing where direnv stores its cache][cache_location]

--- a/direnvrc
+++ b/direnvrc
@@ -211,17 +211,6 @@ _nix_add_gcroot() {
   _nix build --out-link "$symlink" "$storepath"
 }
 
-_nix_refresh_gcroots() {
-  # Use touch to update all symlinks' timestamps to prevent nh
-  # from garbage collecting the frequently used direnv environment.
-  local layout_dir
-  layout_dir=$(direnv_layout_dir)
-
-  if ! touch -h "${layout_dir}"/flake-profile-* "${layout_dir}"/flake-inputs/* "${layout_dir}"/nix-profile-* 2>/dev/null; then
-    _nix_direnv_warning "could not refresh gcroots; layout directory may be read-only"
-  fi
-}
-
 _nix_clean_old_gcroots() {
   local layout_dir=$1
 
@@ -403,7 +392,6 @@ use_flake() {
     if [[ -e ${profile_rc} ]]; then
       # Our cache is valid, use that
       _nix_direnv_info "Using cached dev shell"
-      _nix_refresh_gcroots
     else
       # We don't have a profile_rc to use!
       _nix_direnv_error "use_flake failed - Is your flake's devShell working?"
@@ -593,7 +581,6 @@ use_nix() {
   else
     if [[ -e ${profile_rc} ]]; then
       _nix_direnv_info "Using cached dev shell"
-      _nix_refresh_gcroots
     else
       _nix_direnv_error "use_nix failed - Is your nix shell working?"
       unset IN_NIX_SHELL


### PR DESCRIPTION
This logic (introduced in #631) conflicts with #745. Because the motivation for #631 was nh's cleanup functionality and that functionality now has a blessed & upstreamed augmentation for this sort of behavior (namely `nh clean --keep-one`) we can safely revert this changeset without reducing general utility.

Closes #786